### PR TITLE
Hibernate 5.2.5 compatibility - fix #13

### DIFF
--- a/hazelcast-hibernate52/pom.xml
+++ b/hazelcast-hibernate52/pom.xml
@@ -29,7 +29,7 @@
     <url>http://www.hazelcast.com/</url>
 
     <properties>
-        <hibernate.core.version>5.2.3.Final</hibernate.core.version>
+        <hibernate.core.version>5.2.5.Final</hibernate.core.version>
         <jdk.version>1.8</jdk.version>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
@@ -110,6 +110,25 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
+                <configuration combine.self="override">
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <runOrder>failedfirst</runOrder>
+                    <argLine>
+                        -Xms128m -Xmx1G -XX:MaxPermSize=128M
+                        -Dhazelcast.phone.home.enabled=false
+                        -Dhazelcast.mancenter.enabled=false
+                        -Dhazelcast.logging.type=none
+                        -Dhazelcast.test.use.network=false
+                    </argLine>
+                    <excludes>
+                        <exclude>**/HibernateSerializationHookAvailableTest.java</exclude>
+                    </excludes>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/region/CacheKeyImpl.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/region/CacheKeyImpl.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.region;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.DataSerializable;
+import org.hibernate.type.Type;
+
+import java.io.IOException;
+
+
+/**
+ * Cache key implementation
+ */
+public class CacheKeyImpl implements DataSerializable {
+    private Object id;
+    private String entityOrRoleName;
+    private String tenantId;
+    private Type type;
+
+    public CacheKeyImpl() {
+    }
+
+    public CacheKeyImpl(Object id, String entityOrRoleName, String tenantId, Type type) {
+        this.id = id;
+        this.entityOrRoleName = entityOrRoleName;
+        this.tenantId = tenantId;
+        this.type = type;
+    }
+
+    Object getId() {
+        return id;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeObject(id);
+        out.writeUTF(entityOrRoleName);
+        out.writeUTF(tenantId);
+        out.writeObject(type);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        id = in.readObject();
+        entityOrRoleName = in.readUTF();
+        tenantId = in.readUTF();
+        type = in.readObject();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        CacheKeyImpl cacheKey = (CacheKeyImpl) o;
+
+        if (!type.isEqual(id, cacheKey.id)) {
+            return false;
+        }
+        if (!entityOrRoleName.equals(cacheKey.entityOrRoleName)) {
+            return false;
+        }
+        return tenantId != null ? tenantId.equals(cacheKey.tenantId) : cacheKey.tenantId == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = type.getHashCode(id);
+        result = 31 * result + entityOrRoleName.hashCode();
+        result = 31 * result + (tenantId != null ? tenantId.hashCode() : 0);
+        return result;
+    }
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/region/CollectionRegionAccessStrategyAdapter.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/region/CollectionRegionAccessStrategyAdapter.java
@@ -18,7 +18,6 @@ package com.hazelcast.hibernate.region;
 
 import com.hazelcast.hibernate.access.AccessDelegate;
 import org.hibernate.cache.CacheException;
-import org.hibernate.cache.internal.DefaultCacheKeysFactory;
 import org.hibernate.cache.spi.CollectionRegion;
 import org.hibernate.cache.spi.access.CollectionRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
@@ -50,7 +49,7 @@ public final class CollectionRegionAccessStrategyAdapter implements CollectionRe
     @Override
     public Object generateCacheKey(final Object id, final CollectionPersister persister,
                                    final SessionFactoryImplementor session, final String tenantIdentifier) {
-        return DefaultCacheKeysFactory.createCollectionKey(id, persister, session, tenantIdentifier);
+        return new CacheKeyImpl(id, persister.getRole(), tenantIdentifier, persister.getKeyType());
     }
 
     @Override
@@ -61,7 +60,7 @@ public final class CollectionRegionAccessStrategyAdapter implements CollectionRe
 
     @Override
     public Object getCacheKeyId(final Object cacheKey) {
-        return DefaultCacheKeysFactory.getCollectionId(cacheKey);
+        return ((CacheKeyImpl) cacheKey).getId();
     }
 
     @Override

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/region/EntityRegionAccessStrategyAdapter.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/region/EntityRegionAccessStrategyAdapter.java
@@ -18,7 +18,6 @@ package com.hazelcast.hibernate.region;
 
 import com.hazelcast.hibernate.access.AccessDelegate;
 import org.hibernate.cache.CacheException;
-import org.hibernate.cache.internal.DefaultCacheKeysFactory;
 import org.hibernate.cache.spi.EntityRegion;
 import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
@@ -63,7 +62,7 @@ public final class EntityRegionAccessStrategyAdapter implements EntityRegionAcce
     @Override
     public Object generateCacheKey(final Object id, final EntityPersister persister,
                                    final SessionFactoryImplementor session, final String tenantIdentifier) {
-        return DefaultCacheKeysFactory.createEntityKey(id, persister, session, tenantIdentifier);
+        return new CacheKeyImpl(id, persister.getRootEntityName(), tenantIdentifier, persister.getIdentifierType());
     }
 
     @Override
@@ -74,7 +73,7 @@ public final class EntityRegionAccessStrategyAdapter implements EntityRegionAcce
 
     @Override
     public Object getCacheKeyId(final Object cacheKey) {
-        return DefaultCacheKeysFactory.getEntityId(cacheKey);
+        return ((CacheKeyImpl) cacheKey).getId();
     }
 
     @Override

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/region/NaturalIdCacheKey.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/region/NaturalIdCacheKey.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.region;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.DataSerializable;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.type.EntityType;
+import org.hibernate.type.Type;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Arrays;
+
+/**
+ * Cache key implementation for natural ID
+ */
+public class NaturalIdCacheKey implements DataSerializable {
+
+    private Serializable[] naturalIdValues;
+    private String entityName;
+    private String tenantId;
+    private int hashCode;
+
+    public NaturalIdCacheKey() {
+    }
+
+    @SuppressWarnings("checkstyle:magicnumber")
+    public NaturalIdCacheKey(final Object[] naturalIdValues, Type[] propertyTypes, int[] naturalIdPropertyIndexes,
+                             final String entityName, final SharedSessionContractImplementor session) {
+
+        this.naturalIdValues = new Serializable[naturalIdValues.length];
+        this.entityName = entityName;
+        this.tenantId = session.getTenantIdentifier();
+
+        SessionFactoryImplementor factory = session.getFactory();
+
+        int result = 1;
+        result = 31 * result + (entityName != null ? entityName.hashCode() : 0);
+        result = 31 * result + (tenantId != null ? tenantId.hashCode() : 0);
+
+        for (int i = 0; i < naturalIdValues.length; i++) {
+            final int naturalIdPropertyIndex = naturalIdPropertyIndexes[i];
+            final Type type = propertyTypes[naturalIdPropertyIndex];
+            final Object value = naturalIdValues[i];
+
+            result = 31 * result + (value != null ? type.getHashCode(value, factory) : 0);
+
+            if (type instanceof EntityType && type.getSemiResolvedType(factory).getReturnedClass().isInstance(value)) {
+                this.naturalIdValues[i] = (Serializable) value;
+            } else {
+                this.naturalIdValues[i] = type.disassemble(value, session, null);
+            }
+        }
+        this.hashCode = result;
+    }
+
+    Serializable[] getNaturalIdValues() {
+        return naturalIdValues;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeInt(naturalIdValues.length);
+        for (Serializable naturalIdValue : naturalIdValues) {
+            out.writeObject(naturalIdValue);
+        }
+        out.writeUTF(entityName);
+        out.writeUTF(tenantId);
+        out.writeInt(hashCode);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        int length = in.readInt();
+        naturalIdValues = new Serializable[length];
+        for (int i = 0; i < length; i++) {
+            naturalIdValues[i] = in.readObject();
+        }
+        entityName = in.readUTF();
+        tenantId = in.readUTF();
+        hashCode = in.readInt();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        NaturalIdCacheKey that = (NaturalIdCacheKey) o;
+
+        if (!Arrays.deepEquals(naturalIdValues, that.naturalIdValues)) {
+            return false;
+        }
+        if (entityName != null ? !entityName.equals(that.entityName) : that.entityName != null) {
+            return false;
+        }
+        return tenantId != null ? tenantId.equals(that.tenantId) : that.tenantId == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return hashCode;
+    }
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/region/NaturalIdRegionAccessStrategyAdapter.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/region/NaturalIdRegionAccessStrategyAdapter.java
@@ -18,7 +18,6 @@ package com.hazelcast.hibernate.region;
 
 import com.hazelcast.hibernate.access.AccessDelegate;
 import org.hibernate.cache.CacheException;
-import org.hibernate.cache.internal.DefaultCacheKeysFactory;
 import org.hibernate.cache.spi.NaturalIdRegion;
 import org.hibernate.cache.spi.access.NaturalIdRegionAccessStrategy;
 import org.hibernate.cache.spi.access.SoftLock;
@@ -61,7 +60,8 @@ public final class NaturalIdRegionAccessStrategyAdapter implements NaturalIdRegi
     @Override
     public Object generateCacheKey(final Object[] naturalIdValues, final EntityPersister persister,
                                    final SharedSessionContractImplementor session) {
-        return DefaultCacheKeysFactory.createNaturalIdKey(naturalIdValues, persister, session);
+        return new NaturalIdCacheKey(naturalIdValues,  persister.getPropertyTypes(),
+                persister.getNaturalIdentifierProperties(), persister.getRootEntityName(), session);
     }
 
     @Override
@@ -72,7 +72,7 @@ public final class NaturalIdRegionAccessStrategyAdapter implements NaturalIdRegi
 
     @Override
     public Object[] getNaturalIdValues(final Object cacheKey) {
-        return DefaultCacheKeysFactory.getNaturalIdValues(cacheKey);
+        return ((NaturalIdCacheKey) cacheKey).getNaturalIdValues();
     }
 
     @Override


### PR DESCRIPTION
Uses DataSerializable cache key classes instead of Hibernate's classes.