### PR TITLE
Made it possible to change hazelcast instance factory. Fixes #21.

### DIFF
--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
@@ -17,7 +17,7 @@
 package com.hazelcast.hibernate;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.hibernate.instance.HazelcastInstanceFactory;
+import com.hazelcast.hibernate.instance.IHazelcastInstanceFactory;
 import com.hazelcast.hibernate.instance.IHazelcastInstanceLoader;
 import com.hazelcast.hibernate.local.CleanupService;
 import com.hazelcast.hibernate.region.HazelcastQueryResultsRegion;
@@ -79,7 +79,21 @@ public abstract class AbstractHazelcastCacheRegionFactory implements RegionFacto
     public void start(final SessionFactoryOptions options, final Properties properties) throws CacheException {
         log.info("Starting up " + getClass().getSimpleName());
         if (instance == null || !instance.getLifecycleService().isRunning()) {
-            instanceLoader = HazelcastInstanceFactory.createInstanceLoader(properties);
+            String factory = properties.getProperty("hibernate.cache.hazelcast.factory", "com.hazelcast.hibernate.instance.DefaultHazelcastInstanceFactory");
+            try
+            {
+                Class<IHazelcastInstanceFactory> factoryClazz = (Class<IHazelcastInstanceFactory>) Class.forName(factory, true, Thread.currentThread().getContextClassLoader());
+                instanceLoader = factoryClazz.newInstance().createInstanceLoader(properties);
+            } catch (ClassNotFoundException e)
+            {
+                throw new CacheException("Failed to set up hazelcast instance factory", e);
+            } catch (InstantiationException e)
+            {
+                throw new CacheException("Failed to set up hazelcast instance factory", e);
+            } catch (IllegalAccessException e)
+            {
+                throw new CacheException("Failed to set up hazelcast instance factory", e);
+            }
             instance = instanceLoader.loadInstance();
         }
         cleanupService = new CleanupService(instance.getName());

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/CacheEnvironment.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/CacheEnvironment.java
@@ -21,6 +21,12 @@ import org.hibernate.cfg.Environment;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.internal.util.config.ConfigurationHelper;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
 import java.util.Properties;
 
 /**
@@ -99,7 +105,7 @@ public final class CacheEnvironment {
     /**
      * Property to configure which {@link com.hazelcast.hibernate.instance.IHazelcastInstanceFactory}
      * that shall be used for creating
-     * {@link com.hazelcast.hibernate.instance.IHazelcastInstanceLoader hazelcast instance loaders}
+     * {@link com.hazelcast.hibernate.instance.IHazelcastInstanceLoader hazelcast instance loaders}.
      */
     public static final String HAZELCAST_FACTORY = "hibernate.cache.hazelcast.factory";
 

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/CacheEnvironment.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/CacheEnvironment.java
@@ -21,12 +21,6 @@ import org.hibernate.cfg.Environment;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.internal.util.config.ConfigurationHelper;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
 import java.util.Properties;
 
 /**

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/CacheEnvironment.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/CacheEnvironment.java
@@ -99,7 +99,7 @@ public final class CacheEnvironment {
     /**
      * Property to configure which {@link com.hazelcast.hibernate.instance.IHazelcastInstanceFactory}
      * that shall be used for creating
-     * {@link com.hazelcast.hibernate.instance.IHazelcastInstanceLoader hazelcast instance loaders}
+     * {@link com.hazelcast.hibernate.instance.IHazelcastInstanceLoader hazelcast instance loaders}.
      */
     public static final String HAZELCAST_FACTORY = "hibernate.cache.hazelcast.factory";
 

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/CacheEnvironment.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/CacheEnvironment.java
@@ -99,7 +99,7 @@ public final class CacheEnvironment {
     /**
      * Property to configure which {@link com.hazelcast.hibernate.instance.IHazelcastInstanceFactory}
      * that shall be used for creating
-     * {@link com.hazelcast.hibernate.instance.IHazelcastInstanceLoader hazelcast instance loaders}.
+     * {@link com.hazelcast.hibernate.instance.IHazelcastInstanceLoader hazelcast instance loaders}
      */
     public static final String HAZELCAST_FACTORY = "hibernate.cache.hazelcast.factory";
 

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/CacheEnvironment.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/CacheEnvironment.java
@@ -96,6 +96,13 @@ public final class CacheEnvironment {
      */
     public static final String HAZELCAST_SHUTDOWN_HOOK_ENABLED = "hazelcast.shutdownhook.enabled";
 
+    /**
+     * Property to configure which {@link com.hazelcast.hibernate.instance.IHazelcastInstanceFactory}
+     * that shall be used for creating
+     * {@link com.hazelcast.hibernate.instance.IHazelcastInstanceLoader hazelcast instance loaders}
+     */
+    public static final String HAZELCAST_FACTORY = "hibernate.cache.hazelcast.factory";
+
     // milliseconds
     private static final int MAXIMUM_LOCK_TIMEOUT = 10000;
 

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/instance/DefaultHazelcastInstanceFactory.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/instance/DefaultHazelcastInstanceFactory.java
@@ -22,27 +22,18 @@ import org.hibernate.cache.CacheException;
 import java.util.Properties;
 
 /**
- * A factory class to build up implementations of {@link com.hazelcast.hibernate.instance.IHazelcastInstanceLoader}
- * that returns a {@link com.hazelcast.core.HazelcastInstance} depending on configuration either backed by Hazelcast
+ * A factory that returns a {@link com.hazelcast.core.HazelcastInstance} depending on configuration either backed by Hazelcast
  * client or node implementation.
  */
-public final class HazelcastInstanceFactory {
-
+public final class DefaultHazelcastInstanceFactory implements IHazelcastInstanceFactory
+{
     private static final String HZ_CLIENT_LOADER_CLASSNAME = "com.hazelcast.hibernate.instance.HazelcastClientLoader";
     private static final String HZ_INSTANCE_LOADER_CLASSNAME = "com.hazelcast.hibernate.instance.HazelcastInstanceLoader";
 
-    private HazelcastInstanceFactory() {
-    }
-
-    public static IHazelcastInstanceLoader createInstanceLoader(final Properties props) throws CacheException {
+    public IHazelcastInstanceLoader createInstanceLoader(final Properties props) throws CacheException {
         try {
-            IHazelcastInstanceLoader instanceLoader = (IHazelcastInstanceLoader) props.
-                    get("com.hazelcast.hibernate.instance.loader");
-            if (instanceLoader != null) {
-                return instanceLoader;
-            }
             Class loaderClass = getInstanceLoaderClass(props);
-            instanceLoader = (IHazelcastInstanceLoader) loaderClass.newInstance();
+            IHazelcastInstanceLoader instanceLoader = (IHazelcastInstanceLoader) loaderClass.newInstance();
             instanceLoader.configure(props);
             return instanceLoader;
         } catch (Exception e) {
@@ -51,7 +42,7 @@ public final class HazelcastInstanceFactory {
     }
 
     private static Class getInstanceLoaderClass(final Properties props) throws ClassNotFoundException {
-        ClassLoader cl = HazelcastInstanceFactory.class.getClassLoader();
+        ClassLoader cl = DefaultHazelcastInstanceFactory.class.getClassLoader();
         if (props != null && CacheEnvironment.isNativeClient(props)) {
             return cl.loadClass(HZ_CLIENT_LOADER_CLASSNAME);
         } else {

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/instance/HazelcastInstanceLoader.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/instance/HazelcastInstanceLoader.java
@@ -36,7 +36,7 @@ import java.util.Properties;
  */
 class HazelcastInstanceLoader implements IHazelcastInstanceLoader {
 
-    private static final ILogger LOGGER = Logger.getLogger(HazelcastInstanceFactory.class);
+    private static final ILogger LOGGER = Logger.getLogger(IHazelcastInstanceFactory.class);
 
     private HazelcastInstance instance;
     private Config config;

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/instance/IHazelcastInstanceFactory.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/instance/IHazelcastInstanceFactory.java
@@ -23,7 +23,6 @@ import java.util.Properties;
 /**
  * A hookable factory class to build up implementations of {@link com.hazelcast.hibernate.instance.IHazelcastInstanceLoader}
  */
-public interface IHazelcastInstanceFactory
-{
+public interface IHazelcastInstanceFactory {
     IHazelcastInstanceLoader createInstanceLoader(final Properties props) throws CacheException;
 }

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/instance/IHazelcastInstanceFactory.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/instance/IHazelcastInstanceFactory.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.instance;
+
+import org.hibernate.cache.CacheException;
+
+import java.util.Properties;
+
+/**
+ * A hookable factory class to build up implementations of {@link com.hazelcast.hibernate.instance.IHazelcastInstanceLoader}
+ */
+public interface IHazelcastInstanceFactory
+{
+    IHazelcastInstanceLoader createInstanceLoader(final Properties props) throws CacheException;
+}

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/HibernateTestSupport.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/HibernateTestSupport.java
@@ -20,6 +20,7 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.hibernate.entity.AnnotatedEntity;
 import com.hazelcast.hibernate.instance.HazelcastAccessor;
+import com.hazelcast.hibernate.instance.HazelcastMockInstanceFactory;
 import com.hazelcast.hibernate.instance.IHazelcastInstanceLoader;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
@@ -76,10 +77,11 @@ public abstract class HibernateTestSupport extends HazelcastTestSupport {
                                                   final IHazelcastInstanceLoader customInstanceLoader) {
         props.put(CacheEnvironment.EXPLICIT_VERSION_CHECK, "true");
         if (customInstanceLoader != null) {
-            props.put("com.hazelcast.hibernate.instance.loader", customInstanceLoader);
+            HazelcastMockInstanceFactory.setThreadLocalLoader(customInstanceLoader);
+            props.setProperty("hibernate.cache.hazelcast.factory", "com.hazelcast.hibernate.instance.HazelcastMockInstanceFactory");
             customInstanceLoader.configure(props);
         } else {
-            props.remove("com.hazelcast.hibernate.instance.loader");
+            props.remove("hibernate.cache.hazelcast.factory");
         }
 
         final Configuration conf = new Configuration();

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/instance/HazelcastMockInstanceFactory.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/instance/HazelcastMockInstanceFactory.java
@@ -1,0 +1,21 @@
+package com.hazelcast.hibernate.instance;
+
+import org.hibernate.cache.CacheException;
+
+import java.util.Properties;
+
+public class HazelcastMockInstanceFactory implements IHazelcastInstanceFactory
+{
+	private static ThreadLocal<IHazelcastInstanceLoader> loaders = new ThreadLocal<IHazelcastInstanceLoader>();
+
+	public static void setThreadLocalLoader(IHazelcastInstanceLoader loader)
+	{
+		loaders.set(loader);
+	}
+
+	@Override
+	public IHazelcastInstanceLoader createInstanceLoader(Properties props) throws CacheException
+	{
+		return loaders.get();
+	}
+}


### PR DESCRIPTION
This is better because many third-party db libraries assume that properties in Properties are Strings, not objects.