### PR TITLE
Issue 40 - Add clear support on TimestampsRegionCache

### DIFF
--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/local/TimestampsRegionCache.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/local/TimestampsRegionCache.java
@@ -47,6 +47,12 @@ public class TimestampsRegionCache extends LocalRegionCache implements RegionCac
         final Timestamp ts = (Timestamp) messageObject;
         final Object key = ts.getKey();
 
+        if (key == null) {
+            // Invalidate the entire region cache.
+            cache.clear();
+            return;
+        }
+
         for (; ; ) {
             final Expirable value = cache.get(key);
             final Long current = value != null ? (Long) value.getValue() : null;
@@ -69,6 +75,12 @@ public class TimestampsRegionCache extends LocalRegionCache implements RegionCac
     @Override
     protected Object createMessage(final Object key, final Object value, final Object currentVersion) {
         return new Timestamp(key, (Long) value);
+    }
+
+    @Override
+    public void clear() {
+        cache.clear();
+        maybeNotifyTopic(null, -1L, null);
     }
 
     @Override

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/local/TimestampsRegionCacheTest.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/local/TimestampsRegionCacheTest.java
@@ -1,5 +1,6 @@
 package com.hazelcast.hibernate.local;
 
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.eq;
@@ -76,4 +77,15 @@ public class TimestampsRegionCacheTest {
         // this fails if we use system time instead of cluster time, causing the value to stay invisible until clustertime == system time (which it often isn't)
         assertThat("key should be visible and have value specified in timestamp message, with current cluster time.", (Long)target.get("QuerySpace", clusterTime), is(secondTimestamp));
     }
+
+    @Test
+    public void clearCache() {
+        long aTimestamp = 1;
+        assertThat(target.put("QuerySpace", aTimestamp, aTimestamp, null), is(true));
+        assertThat("value should be in the cache", (Long)target.get("QuerySpace", aTimestamp), is(aTimestamp));
+
+        target.clear();
+
+        assertThat("value should not be in the cache", target.get("QuerySpace", aTimestamp), nullValue());
+    }    
 }


### PR DESCRIPTION
Fixes issue https://github.com/hazelcast/hazelcast-hibernate5/issues/40
Uses a null key and a -1L value to propagate a local cache clear call.