### PR TITLE
Issue 44 - Support Hibernate 5.3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Hazelcast provides a distributed second level cache for your Hibernate entities,
 
 `hazelcast-hibernate52` supports Java 8, Hibernate 5.2.x and Hazelcast 3.7+
 
+`hazelcast-hibernate53` supports Java 8, Hibernate 5.3.x and Hazelcast 3.7+
+
 ## Development
 
 The project needs to be compiled using Java 8.

--- a/hazelcast-hibernate5/pom.xml
+++ b/hazelcast-hibernate5/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-hibernate5-parent</artifactId>
-        <version>1.2.4-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
     <artifactId>hazelcast-hibernate5</artifactId>
     <packaging>jar</packaging>
@@ -29,6 +29,35 @@
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
     </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+                <version>${maven.animal.sniffer.plugin.version}</version>
+                <configuration>
+                    <signature>
+                        <groupId>org.codehaus.mojo.signature</groupId>
+                        <artifactId>java16</artifactId>
+                        <version>1.0</version>
+                    </signature>
+                    <ignores>
+                        <ignore>sun.misc.Unsafe</ignore>
+                    </ignores>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>source-java6-check</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
     <profiles>
         <profile>

--- a/hazelcast-hibernate53/pom.xml
+++ b/hazelcast-hibernate53/pom.xml
@@ -20,29 +20,22 @@
         <artifactId>hazelcast-hibernate5-parent</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
-    <artifactId>hazelcast-hibernate52</artifactId>
+    <artifactId>hazelcast-hibernate53</artifactId>
     <packaging>jar</packaging>
     <description>Hazelcast In-Memory DataGrid Hibernate Plugin</description>
     <url>http://www.hazelcast.com/</url>
 
     <properties>
-        <hibernate.core.version>5.2.5.Final</hibernate.core.version>
+        <hibernate.core.version>5.3.7.Final</hibernate.core.version>
         <jdk.version>1.8</jdk.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <bytebuddy.version>1.8.17</bytebuddy.version>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
     </properties>
 
     <build>
-        <!-- Reuse tests from hibernate5 module -->
-        <testSourceDirectory>../hazelcast-hibernate5/src/test/java</testSourceDirectory>
-        <testResources>
-            <testResource>
-                <directory>../hazelcast-hibernate5/src/test/resources</directory>
-            </testResource>
-        </testResources>
-
         <!-- Overlay code onto hibernate5 module -->
         <plugins>
             <plugin>
@@ -62,11 +55,16 @@
                                 <resource>
                                     <directory>../hazelcast-hibernate5/src/main/java</directory>
                                     <excludes>
-                                        <exclude>com/hazelcast/hibernate/region/AbstractGeneralRegion.java</exclude>
-                                        <exclude>com/hazelcast/hibernate/region/CollectionRegionAccessStrategyAdapter.java</exclude>
-                                        <exclude>com/hazelcast/hibernate/region/HazelcastCacheKeysFactory.java</exclude>
-                                        <exclude>com/hazelcast/hibernate/region/NaturalIdRegionAccessStrategyAdapter.java</exclude>
-                                        <exclude>com/hazelcast/hibernate/region/EntityRegionAccessStrategyAdapter.java</exclude>
+                                        <exclude>com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java</exclude>
+                                        <exclude>com/hazelcast/hibernate/HazelcastCacheRegionFactory.java</exclude>
+                                        <exclude>com/hazelcast/hibernate/HazelcastLocalCacheRegionFactory.java</exclude>
+                                        <exclude>com/hazelcast/hibernate/HazelcastTimestamper.java</exclude>
+                                        <exclude>com/hazelcast/hibernate/RegionCache.java</exclude>
+                                        <exclude>com/hazelcast/hibernate/distributed/IMapRegionCache.java</exclude>
+                                        <exclude>com/hazelcast/hibernate/local/LocalRegionCache.java</exclude>
+                                        <exclude>com/hazelcast/hibernate/local/TimestampsRegionCache.java</exclude>
+                                        <exclude>com/hazelcast/hibernate/access/**.java</exclude>
+                                        <exclude>com/hazelcast/hibernate/region/**.java</exclude>
                                         <exclude>com/hazelcast/hibernate/serialization/Hibernate5CacheEntrySerializerHook.java</exclude>
                                         <exclude>com/hazelcast/hibernate/serialization/Hibernate5CacheEntrySerializer.java</exclude>
                                         <exclude>com/hazelcast/hibernate/serialization/Hibernate51CacheEntrySerializer.java</exclude>
@@ -91,6 +89,54 @@
                             </resources>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>copy-test-sources</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/generated-test-sources</outputDirectory>
+                            <overwrite>false</overwrite>
+                            <resources>
+                                <resource>
+                                    <directory>../hazelcast-hibernate5/src/test/java</directory>
+                                    <excludes>
+                                        <exclude>com/hazelcast/hibernate/CacheHitMissNonStrictTest.java</exclude>
+                                        <exclude>com/hazelcast/hibernate/CacheHitMissReadOnlyTest.java</exclude>
+                                        <exclude>com/hazelcast/hibernate/CacheHitMissReadWriteTest.java</exclude>
+                                        <exclude>com/hazelcast/hibernate/CustomPropertiesTest.java</exclude>
+                                        <exclude>com/hazelcast/hibernate/NaturalIdTest.java</exclude>
+                                        <exclude>com/hazelcast/hibernate/RegionFactoryDefaultSlowTest.java</exclude>
+                                        <exclude>com/hazelcast/hibernate/access/**.java</exclude>
+                                        <exclude>com/hazelcast/hibernate/region/**.java</exclude>
+                                        <exclude>com/hazelcast/hibernate/local/LocalRegionCacheTest.java</exclude>
+                                        <exclude>com/hazelcast/hibernate/local/TimestampsRegionCacheTest.java</exclude>
+                                        <exclude>com/hazelcast/hibernate/serialization/HibernateSerializationHookNonAvailableTest.java</exclude>
+                                    </excludes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-test-resources</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/test-classes</outputDirectory>
+                            <overwrite>false</overwrite>
+                            <resources>
+                                <resource>
+                                    <directory>../hazelcast-hibernate5/src/test/resources</directory>
+                                    <excludes>
+                                        <exclude>hazelcast-custom.xml</exclude>
+                                    </excludes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -99,6 +145,7 @@
                 <version>${build.helper.maven.plugin.version}</version>
                 <executions>
                     <execution>
+                        <id>generate-sources</id>
                         <phase>generate-sources</phase>
                         <goals>
                             <goal>add-source</goal>
@@ -106,6 +153,18 @@
                         <configuration>
                             <sources>
                                 <source>${project.build.directory}/generated-sources</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>generate-test-sources</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.build.directory}/generated-test-sources</source>
                             </sources>
                         </configuration>
                     </execution>

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
@@ -101,9 +101,9 @@ public abstract class AbstractHazelcastCacheRegionFactory extends RegionFactoryT
         return new HazelcastStorageAccessImpl(regionCache);
     }
 
-    protected abstract RegionCache createRegionCache(String unqualifiedRegionName,
-                                                     SessionFactoryImplementor sessionFactory,
-                                                     DomainDataRegionConfig regionConfig);
+    protected abstract RegionCache createRegionCache(final String unqualifiedRegionName,
+                                                     final SessionFactoryImplementor sessionFactory,
+                                                     final DomainDataRegionConfig regionConfig);
 
     @Override
     protected StorageAccess createTimestampsRegionStorageAccess(final String regionName,
@@ -113,8 +113,8 @@ public abstract class AbstractHazelcastCacheRegionFactory extends RegionFactoryT
         );
     }
 
-    protected abstract RegionCache createTimestampsRegionCache(String regionName,
-                                                               SessionFactoryImplementor sessionFactory);
+    protected abstract RegionCache createTimestampsRegionCache(final String regionName,
+                                                               final SessionFactoryImplementor sessionFactory);
 
     @Override
     protected CacheKeysFactory getImplicitCacheKeysFactory() {

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.instance.DefaultHazelcastInstanceFactory;
+import com.hazelcast.hibernate.instance.IHazelcastInstanceFactory;
+import com.hazelcast.hibernate.instance.IHazelcastInstanceLoader;
+import com.hazelcast.hibernate.local.CleanupService;
+import com.hazelcast.hibernate.local.LocalRegionCache;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import org.hibernate.boot.spi.SessionFactoryOptions;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.cfg.spi.DomainDataRegionBuildingContext;
+import org.hibernate.cache.cfg.spi.DomainDataRegionConfig;
+import org.hibernate.cache.internal.DefaultCacheKeysFactory;
+import org.hibernate.cache.spi.CacheKeysFactory;
+import org.hibernate.cache.spi.DomainDataRegion;
+import org.hibernate.cache.spi.support.DomainDataStorageAccess;
+import org.hibernate.cache.spi.support.RegionFactoryTemplate;
+import org.hibernate.cache.spi.support.StorageAccess;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Simple RegionFactory implementation to return Hazelcast based local Region implementations
+ */
+public abstract class AbstractHazelcastCacheRegionFactory extends RegionFactoryTemplate {
+
+    protected CleanupService cleanupService;
+    protected HazelcastInstance instance;
+
+    private final CacheKeysFactory cacheKeysFactory;
+    private final ILogger log = Logger.getLogger(getClass());
+
+    private IHazelcastInstanceLoader instanceLoader;
+
+    @SuppressWarnings("unused")
+    public AbstractHazelcastCacheRegionFactory() {
+        this(DefaultCacheKeysFactory.INSTANCE);
+    }
+
+    public AbstractHazelcastCacheRegionFactory(final CacheKeysFactory cacheKeysFactory) {
+        this.cacheKeysFactory = cacheKeysFactory;
+    }
+
+    public AbstractHazelcastCacheRegionFactory(final HazelcastInstance instance) {
+        this.instance = instance;
+
+        cacheKeysFactory = DefaultCacheKeysFactory.INSTANCE;
+    }
+
+    @Override
+    public DomainDataRegion buildDomainDataRegion(final DomainDataRegionConfig regionConfig,
+                                                  final DomainDataRegionBuildingContext buildingContext) {
+        return new HazelcastDomainDataRegionImpl(
+                regionConfig,
+                this,
+                createDomainDataStorageAccess(regionConfig, buildingContext),
+                cacheKeysFactory,
+                buildingContext
+        );
+    }
+
+    public HazelcastInstance getHazelcastInstance() {
+        return instance;
+    }
+
+    @Override
+    protected DomainDataStorageAccess createDomainDataStorageAccess(final DomainDataRegionConfig regionConfig,
+                                                                    final DomainDataRegionBuildingContext buildingContext) {
+        return new HazelcastStorageAccessImpl(
+                createRegionCache(regionConfig.getRegionName(), buildingContext.getSessionFactory(), regionConfig)
+        );
+    }
+
+    @Override
+    protected StorageAccess createQueryResultsRegionStorageAccess(final String regionName,
+                                                                  final SessionFactoryImplementor sessionFactory) {
+        // Note: We don't want to use an ITopic for invalidation because the timestamps cache can take care of outdated
+        // queries
+        final LocalRegionCache regionCache = new LocalRegionCache(this, regionName, instance, null, false);
+        cleanupService.registerCache(regionCache);
+        return new HazelcastStorageAccessImpl(regionCache);
+    }
+
+    protected abstract RegionCache createRegionCache(String unqualifiedRegionName,
+                                                     SessionFactoryImplementor sessionFactory,
+                                                     DomainDataRegionConfig regionConfig);
+
+    @Override
+    protected StorageAccess createTimestampsRegionStorageAccess(final String regionName,
+                                                                final SessionFactoryImplementor sessionFactory) {
+        return new HazelcastStorageAccessImpl(
+                createTimestampsRegionCache(regionName, sessionFactory)
+        );
+    }
+
+    protected abstract RegionCache createTimestampsRegionCache(String regionName,
+                                                               SessionFactoryImplementor sessionFactory);
+
+    @Override
+    protected CacheKeysFactory getImplicitCacheKeysFactory() {
+        return cacheKeysFactory;
+    }
+
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // Lifecycle
+
+    @Override
+    protected boolean isStarted() {
+        return super.isStarted() && instance.getLifecycleService().isRunning();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected void prepareForUse(final SessionFactoryOptions settings, final Map configValues) {
+        log.info("Starting up " + getClass().getSimpleName());
+        if (instance == null || !instance.getLifecycleService().isRunning()) {
+            final String defaultFactory = DefaultHazelcastInstanceFactory.class.getName();
+
+            String factoryName = (String) configValues.get(CacheEnvironment.HAZELCAST_FACTORY);
+            if (factoryName == null) {
+                factoryName = defaultFactory;
+            }
+
+            final ClassLoader cl = Thread.currentThread().getContextClassLoader();
+            try {
+                final Class<IHazelcastInstanceFactory> factory =
+                        (Class<IHazelcastInstanceFactory>) Class.forName(factoryName, true, cl);
+                instanceLoader = factory.newInstance().createInstanceLoader(toProperties(configValues));
+            } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+                throw new CacheException("Failed to set up hazelcast instance factory", e);
+            }
+            instance = instanceLoader.loadInstance();
+        }
+        cleanupService = new CleanupService(instance.getName());
+    }
+
+    @SuppressWarnings("Duplicates")
+    @Override
+    protected void releaseFromUse() {
+        if (instanceLoader != null) {
+            log.info("Shutting down " + getClass().getSimpleName());
+            instanceLoader.unloadInstance();
+            instance = null;
+            instanceLoader = null;
+        }
+        cleanupService.stop();
+    }
+
+    private Properties toProperties(final Map configValues) {
+        final Properties properties = new Properties();
+        properties.putAll(configValues);
+        return properties;
+    }
+}

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/HazelcastCacheRegionFactory.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/HazelcastCacheRegionFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.distributed.IMapRegionCache;
+import org.hibernate.cache.cfg.spi.DomainDataRegionConfig;
+import org.hibernate.cache.spi.CacheKeysFactory;
+import org.hibernate.cache.spi.support.RegionNameQualifier;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+
+/**
+ * Simple RegionFactory implementation to return Hazelcast based Region implementations
+ */
+public class HazelcastCacheRegionFactory extends AbstractHazelcastCacheRegionFactory {
+
+    public HazelcastCacheRegionFactory() {
+    }
+
+    public HazelcastCacheRegionFactory(final CacheKeysFactory cacheKeysFactory) {
+        super(cacheKeysFactory);
+    }
+
+    public HazelcastCacheRegionFactory(final HazelcastInstance instance) {
+        super(instance);
+    }
+
+    @Override
+    protected RegionCache createRegionCache(final String unqualifiedRegionName,
+                                            final SessionFactoryImplementor sessionFactory,
+                                            final DomainDataRegionConfig regionConfig) {
+        verifyStarted();
+        assert !RegionNameQualifier.INSTANCE.isQualified(unqualifiedRegionName, sessionFactory.getSessionFactoryOptions());
+
+        final String qualifiedRegionName = RegionNameQualifier.INSTANCE.qualify(
+                unqualifiedRegionName,
+                sessionFactory.getSessionFactoryOptions()
+        );
+
+        return new IMapRegionCache(this, qualifiedRegionName, instance);
+    }
+
+    @Override
+    protected RegionCache createTimestampsRegionCache(final String unqualifiedRegionName,
+                                                      final SessionFactoryImplementor sessionFactory) {
+        verifyStarted();
+        assert !RegionNameQualifier.INSTANCE.isQualified(unqualifiedRegionName, sessionFactory.getSessionFactoryOptions());
+
+        final String qualifiedRegionName = RegionNameQualifier.INSTANCE.qualify(
+                unqualifiedRegionName,
+                sessionFactory.getSessionFactoryOptions()
+        );
+
+        return new IMapRegionCache(this, qualifiedRegionName, instance);
+    }
+}

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/HazelcastDomainDataRegionImpl.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/HazelcastDomainDataRegionImpl.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import org.hibernate.cache.cfg.spi.CollectionDataCachingConfig;
+import org.hibernate.cache.cfg.spi.DomainDataRegionBuildingContext;
+import org.hibernate.cache.cfg.spi.DomainDataRegionConfig;
+import org.hibernate.cache.cfg.spi.EntityDataCachingConfig;
+import org.hibernate.cache.spi.CacheKeysFactory;
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cache.spi.access.CollectionDataAccess;
+import org.hibernate.cache.spi.access.EntityDataAccess;
+import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.cache.spi.support.CollectionReadWriteAccess;
+import org.hibernate.cache.spi.support.CollectionTransactionAccess;
+import org.hibernate.cache.spi.support.DomainDataRegionImpl;
+import org.hibernate.cache.spi.support.DomainDataStorageAccess;
+import org.hibernate.cache.spi.support.EntityReadWriteAccess;
+import org.hibernate.cache.spi.support.EntityTransactionalAccess;
+import org.hibernate.cache.spi.support.RegionFactoryTemplate;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+
+/**
+ * Hazelcast based timestamp using region implementation
+ */
+public class HazelcastDomainDataRegionImpl extends DomainDataRegionImpl {
+
+    HazelcastDomainDataRegionImpl(final DomainDataRegionConfig regionConfig,
+                                  final RegionFactoryTemplate regionFactory,
+                                  final DomainDataStorageAccess domainDataStorageAccess,
+                                  final CacheKeysFactory defaultKeysFactory,
+                                  final DomainDataRegionBuildingContext buildingContext) {
+        super(regionConfig, regionFactory, domainDataStorageAccess, defaultKeysFactory, buildingContext);
+    }
+
+    @Override
+    public CollectionDataAccess generateCollectionAccess(final CollectionDataCachingConfig accessConfig) {
+        if (accessConfig.getAccessType() == AccessType.READ_WRITE) {
+            return generateReadWriteCollectionAccess(accessConfig);
+        } else {
+            return super.generateCollectionAccess(accessConfig);
+        }
+    }
+
+    @Override
+    protected EntityDataAccess generateReadWriteEntityAccess(final EntityDataCachingConfig accessConfig) {
+        return new EntityReadWriteAccess(this, getEffectiveKeysFactory(), getCacheStorageAccess(), accessConfig) {
+            @Override
+            public boolean afterUpdate(final SharedSessionContractImplementor session, final Object key,
+                                       final Object value, final Object currentVersion, final Object previousVersion,
+                                       final SoftLock lock) {
+                final boolean result = super.afterUpdate(session, key, value, currentVersion, previousVersion, lock);
+                ((HazelcastStorageAccess) getStorageAccess()).afterUpdate(key, value, currentVersion);
+                return result;
+            }
+        };
+    }
+
+    @Override
+    protected CollectionDataAccess generateTransactionalCollectionDataAccess(
+            final CollectionDataCachingConfig accessConfig) {
+        return new CollectionTransactionAccess(this, getEffectiveKeysFactory(), getCacheStorageAccess(), accessConfig) {
+            @Override
+            public void unlockItem(final SharedSessionContractImplementor session, final Object key,
+                                   final SoftLock lock) {
+                super.unlockItem(session, key, lock);
+                ((HazelcastStorageAccess) getStorageAccess()).unlockItem(key, lock);
+            }
+        };
+    }
+
+    @Override
+    protected EntityDataAccess generateTransactionalEntityDataAccess(final EntityDataCachingConfig accessConfig) {
+        return new EntityTransactionalAccess(this, getEffectiveKeysFactory(), getCacheStorageAccess(), accessConfig) {
+            @Override
+            public boolean afterUpdate(final SharedSessionContractImplementor session, final Object key,
+                                       final Object value, final Object currentVersion, final Object previousVersion,
+                                       final SoftLock lock) {
+                final boolean result = super.afterUpdate(session, key, value, currentVersion, previousVersion, lock);
+                ((HazelcastStorageAccess) getStorageAccess()).afterUpdate(key, value, currentVersion);
+                return result;
+            }
+        };
+    }
+
+    private CollectionDataAccess generateReadWriteCollectionAccess(final CollectionDataCachingConfig accessConfig) {
+        return new CollectionReadWriteAccess(this, getEffectiveKeysFactory(), getCacheStorageAccess(), accessConfig) {
+            @Override
+            public void unlockItem(final SharedSessionContractImplementor session, final Object key,
+                                   final SoftLock lock) {
+                super.unlockItem(session, key, lock);
+                ((HazelcastStorageAccess) getStorageAccess()).unlockItem(key, lock);
+            }
+        };
+    }
+}

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/HazelcastLocalCacheRegionFactory.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/HazelcastLocalCacheRegionFactory.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.local.LocalRegionCache;
+import com.hazelcast.hibernate.local.TimestampsRegionCache;
+import org.hibernate.cache.cfg.spi.DomainDataRegionConfig;
+import org.hibernate.cache.spi.CacheKeysFactory;
+import org.hibernate.cache.spi.support.RegionNameQualifier;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+
+/**
+ * Simple RegionFactory implementation to return Hazelcast based local Region implementations
+ */
+public class HazelcastLocalCacheRegionFactory extends AbstractHazelcastCacheRegionFactory {
+
+    public HazelcastLocalCacheRegionFactory() {
+    }
+
+    public HazelcastLocalCacheRegionFactory(final CacheKeysFactory cacheKeysFactory) {
+        super(cacheKeysFactory);
+    }
+
+    public HazelcastLocalCacheRegionFactory(final HazelcastInstance instance) {
+        super(instance);
+    }
+
+    @Override
+    protected RegionCache createRegionCache(final String unqualifiedRegionName,
+                                            final SessionFactoryImplementor sessionFactory,
+                                            final DomainDataRegionConfig regionConfig) {
+        verifyStarted();
+        assert !RegionNameQualifier.INSTANCE.isQualified(unqualifiedRegionName, sessionFactory.getSessionFactoryOptions());
+
+        final String qualifiedRegionName = RegionNameQualifier.INSTANCE.qualify(
+                unqualifiedRegionName,
+                sessionFactory.getSessionFactoryOptions()
+        );
+
+        final LocalRegionCache regionCache = new LocalRegionCache(this, qualifiedRegionName, instance, regionConfig);
+        cleanupService.registerCache(regionCache);
+        return regionCache;
+    }
+
+    @Override
+    protected RegionCache createTimestampsRegionCache(final String unqualifiedRegionName,
+                                                    final SessionFactoryImplementor sessionFactory) {
+        verifyStarted();
+        assert !RegionNameQualifier.INSTANCE.isQualified(unqualifiedRegionName, sessionFactory.getSessionFactoryOptions());
+
+        final String qualifiedRegionName = RegionNameQualifier.INSTANCE.qualify(
+                unqualifiedRegionName,
+                sessionFactory.getSessionFactoryOptions()
+        );
+
+        return new TimestampsRegionCache(this, qualifiedRegionName, instance);
+    }
+}

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/HazelcastLocalCacheRegionFactory.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/HazelcastLocalCacheRegionFactory.java
@@ -59,7 +59,7 @@ public class HazelcastLocalCacheRegionFactory extends AbstractHazelcastCacheRegi
 
     @Override
     protected RegionCache createTimestampsRegionCache(final String unqualifiedRegionName,
-                                                    final SessionFactoryImplementor sessionFactory) {
+                                                      final SessionFactoryImplementor sessionFactory) {
         verifyStarted();
         assert !RegionNameQualifier.INSTANCE.isQualified(unqualifiedRegionName, sessionFactory.getSessionFactoryOptions());
 

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/HazelcastStorageAccess.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/HazelcastStorageAccess.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.cache.spi.support.DomainDataStorageAccess;
+
+/**
+ * Hazelcast specific interface version of Hibernate's DomainDataStorageAccess
+ */
+public interface HazelcastStorageAccess extends DomainDataStorageAccess {
+
+    void afterUpdate(Object key, Object newValue, Object newVersion);
+
+    void unlockItem(Object key, SoftLock lock);
+
+}

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/HazelcastStorageAccess.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/HazelcastStorageAccess.java
@@ -24,8 +24,8 @@ import org.hibernate.cache.spi.support.DomainDataStorageAccess;
  */
 public interface HazelcastStorageAccess extends DomainDataStorageAccess {
 
-    void afterUpdate(Object key, Object newValue, Object newVersion);
+    void afterUpdate(final Object key, final Object newValue, final Object newVersion);
 
-    void unlockItem(Object key, SoftLock lock);
+    void unlockItem(final Object key, final SoftLock lock);
 
 }

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/HazelcastStorageAccessImpl.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/HazelcastStorageAccessImpl.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.core.OperationTimeoutException;
+import com.hazelcast.logging.Logger;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+
+/**
+ * StorageAccess implementation wrapping a Hazelcast {@link RegionCache} reference.
+ */
+@SuppressWarnings("unchecked")
+public class HazelcastStorageAccessImpl implements HazelcastStorageAccess {
+
+    private final RegionCache delegate;
+
+    HazelcastStorageAccessImpl(final RegionCache delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void afterUpdate(final Object key, final Object newValue, final Object newVersion) {
+        delegate.afterUpdate(key, newValue, newVersion);
+    }
+
+    @Override
+    public boolean contains(final Object key) {
+        return delegate.contains(key);
+    }
+
+    @Override
+    public void evictData() throws CacheException {
+        try {
+            delegate.evictData();
+        } catch (OperationTimeoutException e) {
+            Logger.getLogger(HazelcastStorageAccessImpl.class).finest(e);
+        }
+    }
+
+    @Override
+    public void evictData(final Object key) throws CacheException {
+        try {
+            delegate.evictData(key);
+        } catch (OperationTimeoutException e) {
+            Logger.getLogger(HazelcastStorageAccessImpl.class).finest(e);
+        }
+    }
+
+    @Override
+    public Object getFromCache(final Object key, final SharedSessionContractImplementor session) throws CacheException {
+        try {
+            return delegate.get(key, nextTimestamp());
+        } catch (OperationTimeoutException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public void putIntoCache(final Object key, final Object value, final SharedSessionContractImplementor session)
+            throws CacheException {
+        try {
+            delegate.put(key, value, nextTimestamp(), null);
+        } catch (OperationTimeoutException e) {
+            Logger.getLogger(HazelcastStorageAccessImpl.class).finest(e);
+        }
+    }
+
+    @Override
+    public void release() {
+        // no-op
+    }
+
+    @Override
+    public void unlockItem(final Object key, final SoftLock lock) {
+        delegate.unlockItem(key, lock);
+    }
+
+    RegionCache getDelegate() {
+        return delegate;
+    }
+
+    private long nextTimestamp() {
+        return delegate.nextTimestamp();
+    }
+}

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/RegionCache.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/RegionCache.java
@@ -25,14 +25,14 @@ import org.hibernate.cache.spi.access.SoftLock;
  */
 public interface RegionCache extends Region, ExtendedStatisticsSupport {
 
-    void afterUpdate(Object key, Object newValue, Object newVersion);
+    void afterUpdate(final Object key, final Object newValue, final Object newVersion);
 
     @Override
     default void clear() {
         evictData();
     }
 
-    boolean contains(Object key);
+    boolean contains(final Object key);
 
     @Override
     default void destroy() {
@@ -40,9 +40,9 @@ public interface RegionCache extends Region, ExtendedStatisticsSupport {
 
     void evictData();
 
-    void evictData(Object key);
+    void evictData(final Object key);
 
-    Object get(Object key, long txTimestamp);
+    Object get(final Object key, final long txTimestamp);
 
     @Override
     default long getElementCountOnDisk() {
@@ -53,7 +53,7 @@ public interface RegionCache extends Region, ExtendedStatisticsSupport {
         return getRegionFactory().nextTimestamp();
     }
 
-    boolean put(Object key, Object value, long txTimestamp, Object version);
+    boolean put(final Object key, final Object value, final long txTimestamp, final Object version);
 
-    void unlockItem(Object key, SoftLock lock);
+    void unlockItem(final Object key, final SoftLock lock);
 }

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/RegionCache.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/RegionCache.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import org.hibernate.cache.spi.ExtendedStatisticsSupport;
+import org.hibernate.cache.spi.Region;
+import org.hibernate.cache.spi.access.SoftLock;
+
+/**
+ * This interface defines an internal cached region implementation.
+ */
+public interface RegionCache extends Region, ExtendedStatisticsSupport {
+
+    void afterUpdate(Object key, Object newValue, Object newVersion);
+
+    @Override
+    default void clear() {
+        evictData();
+    }
+
+    boolean contains(Object key);
+
+    @Override
+    default void destroy() {
+    }
+
+    void evictData();
+
+    void evictData(Object key);
+
+    Object get(Object key, long txTimestamp);
+
+    @Override
+    default long getElementCountOnDisk() {
+        return 0;
+    }
+
+    default long nextTimestamp() {
+        return getRegionFactory().nextTimestamp();
+    }
+
+    boolean put(Object key, Object value, long txTimestamp, Object version);
+
+    void unlockItem(Object key, SoftLock lock);
+}

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/StrategyRegistrationProviderImpl.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/StrategyRegistrationProviderImpl.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import org.hibernate.boot.registry.selector.SimpleStrategyRegistrationImpl;
+import org.hibernate.boot.registry.selector.StrategyRegistration;
+import org.hibernate.boot.registry.selector.StrategyRegistrationProvider;
+import org.hibernate.cache.spi.RegionFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Makes the Hazelcast RegionFactory available to the Hibernate
+ * {@link org.hibernate.boot.registry.selector.spi.StrategySelector} service
+ * under a number of keys.
+ */
+public class StrategyRegistrationProviderImpl implements StrategyRegistrationProvider {
+    @Override
+    @SuppressWarnings("unchecked")
+    public Iterable<StrategyRegistration> getStrategyRegistrations() {
+        final List<StrategyRegistration> strategyRegistrations = new ArrayList<>();
+
+        strategyRegistrations.add(
+                new SimpleStrategyRegistrationImpl(
+                        RegionFactory.class,
+                        HazelcastLocalCacheRegionFactory.class,
+                        "hazelcast-local",
+                        HazelcastLocalCacheRegionFactory.class.getName(),
+                        HazelcastLocalCacheRegionFactory.class.getSimpleName()
+                )
+        );
+
+        strategyRegistrations.add(
+                new SimpleStrategyRegistrationImpl(
+                        RegionFactory.class,
+                        HazelcastCacheRegionFactory.class,
+                        "hazelcast",
+                        HazelcastCacheRegionFactory.class.getName(),
+                        HazelcastCacheRegionFactory.class.getSimpleName()
+                )
+        );
+
+        return strategyRegistrations;
+    }
+}

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/distributed/IMapRegionCache.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/distributed/IMapRegionCache.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.distributed;
+
+import com.hazelcast.core.EntryView;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.hibernate.RegionCache;
+import com.hazelcast.hibernate.serialization.Expirable;
+import com.hazelcast.hibernate.serialization.Value;
+import org.hibernate.cache.spi.RegionFactory;
+import org.hibernate.cache.spi.access.SoftLock;
+
+/**
+ * A {@link RegionCache} implementation based on the underlying IMap
+ * <p/>
+ * Note, IMap locks are intentionally not used in this class. Hibernate region caches make use of a concept
+ * called soft-locking which has the following properties:
+ * <ul>
+ *     <li>Multiple transactions can soft-lock an entry concurrently</li>
+ *     <li>While an entry is soft-locked, the value of the cache entry is always {@code null}</li>
+ *     <li>An entry is unlocked from a soft-lock when all transactions complete</li>
+ *     <li>An entry is unlocked if it reaches the configured lock timeout</li>
+ * </ul>
+ * These requirements are incompatible with IMap locks
+ */
+public class IMapRegionCache implements RegionCache {
+
+    private final IMap<Object, Expirable> map;
+    private final String name;
+    private final RegionFactory regionFactory;
+
+    public IMapRegionCache(final RegionFactory regionFactory, final String name,
+                           final HazelcastInstance hazelcastInstance) {
+        this.name = name;
+        this.regionFactory = regionFactory;
+
+        this.map = hazelcastInstance.getMap(this.name);
+    }
+
+    @Override
+    public void afterUpdate(final Object key, final Object newValue, final Object newVersion) {
+        // no-op
+    }
+
+    @Override
+    public boolean contains(final Object key) {
+        return map.containsKey(key);
+    }
+
+    @Override
+    public void evictData() {
+        map.evictAll();
+    }
+
+    @Override
+    public void evictData(final Object key) {
+        map.remove(key);
+    }
+
+    @Override
+    public Object get(final Object key, final long txTimestamp) {
+        final Expirable entry = map.get(key);
+        return entry == null ? null : entry.getValue(txTimestamp);
+    }
+
+    @Override
+    public long getElementCountInMemory() {
+        return map.size();
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public RegionFactory getRegionFactory() {
+        return regionFactory;
+    }
+
+    @Override
+    public long getSizeInMemory() {
+        long size = 0;
+        for (final Object key : map.keySet()) {
+            final EntryView entry = map.getEntryView(key);
+            if (entry != null) {
+                size += entry.getCost();
+            }
+        }
+        return size;
+    }
+
+    @Override
+    public boolean put(final Object key, final Object value, final long txTimestamp, final Object version) {
+        final Value newValue = new Value(version, txTimestamp, value);
+        map.put(key, newValue);
+        return true;
+    }
+
+    @Override
+    public void unlockItem(final Object key, final SoftLock lock) {
+        // no-op
+    }
+}

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/distributed/package-info.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/distributed/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides region interfaces/classes for Hibernate.
+ */
+package com.hazelcast.hibernate.distributed;

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/local/LocalRegionCache.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/local/LocalRegionCache.java
@@ -1,0 +1,362 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.local;
+
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ITopic;
+import com.hazelcast.core.Message;
+import com.hazelcast.core.MessageListener;
+import com.hazelcast.hibernate.CacheEnvironment;
+import com.hazelcast.hibernate.RegionCache;
+import com.hazelcast.hibernate.serialization.Expirable;
+import com.hazelcast.hibernate.serialization.ExpiryMarker;
+import com.hazelcast.hibernate.serialization.Value;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.util.EmptyStatement;
+import org.hibernate.cache.cfg.spi.CollectionDataCachingConfig;
+import org.hibernate.cache.cfg.spi.DomainDataRegionConfig;
+import org.hibernate.cache.cfg.spi.EntityDataCachingConfig;
+import org.hibernate.cache.spi.RegionFactory;
+import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.cache.spi.support.AbstractReadWriteAccess;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Local only {@link RegionCache} implementation based on a topic to distribute cache updates.
+ */
+public class LocalRegionCache implements RegionCache {
+
+    private static final long SEC_TO_MS = 1000L;
+    private static final int MAX_SIZE = 100000;
+    private static final float BASE_EVICTION_RATE = 0.2F;
+
+    protected final ConcurrentMap<Object, Expirable> cache;
+
+    private final ILogger log = Logger.getLogger(getClass());
+    private final String name;
+    private final RegionFactory regionFactory;
+    private final ITopic<Object> topic;
+    private final Comparator versionComparator;
+
+    private MapConfig config;
+
+    /**
+     * @param regionFactory     the region factory
+     * @param name              the name for this region cache, which is also used to retrieve configuration/topic
+     * @param hazelcastInstance the {@code HazelcastInstance} to which this region cache belongs, used to retrieve
+     *                          configuration and to lookup an {@link ITopic} to register a {@link MessageListener}
+     *                          with (optional)
+     * @param regionConfig      the region configuration
+     */
+    public LocalRegionCache(final RegionFactory regionFactory, final String name,
+                            final HazelcastInstance hazelcastInstance, final DomainDataRegionConfig regionConfig) {
+        this(regionFactory, name, hazelcastInstance, regionConfig, true);
+    }
+
+    /**
+     * @param regionFactory     the region factory
+     * @param name              the name for this region cache, which is also used to retrieve configuration/topic
+     * @param hazelcastInstance the {@code HazelcastInstance} to which this region cache belongs, used to retrieve
+     *                          configuration and to lookup an {@link ITopic} to register a {@link MessageListener}
+     *                          with if {@code withTopic} is {@code true} (optional)
+     * @param regionConfig      the region configuration
+     * @param withTopic         {@code true} to register a {@link MessageListener} with the {@link ITopic} whose name
+     *                          matches this region cache <i>if</i> a {@code HazelcastInstance} was provided to look
+     *                          up the topic; otherwise, {@code false} not to register a listener even if an instance
+     *                          was provided
+     */
+    public LocalRegionCache(final RegionFactory regionFactory, final String name,
+                            final HazelcastInstance hazelcastInstance, final DomainDataRegionConfig regionConfig,
+                            final boolean withTopic) {
+        this.name = name;
+        this.regionFactory = regionFactory;
+
+        try {
+            config = hazelcastInstance == null ? null : hazelcastInstance.getConfig().findMapConfig(name);
+        } catch (UnsupportedOperationException ignored) {
+            EmptyStatement.ignore(ignored);
+        }
+        cache = new ConcurrentHashMap<>();
+
+        if (withTopic && hazelcastInstance != null) {
+            topic = hazelcastInstance.getTopic(name);
+            topic.addMessageListener(createMessageListener());
+        } else {
+            topic = null;
+        }
+
+        versionComparator = findVersionComparator(regionConfig);
+    }
+
+    @Override
+    public void afterUpdate(final Object key, final Object newValue, final Object newVersion) {
+        maybeNotifyTopic(key, newValue, newVersion);
+    }
+
+    @Override
+    public boolean contains(final Object key) {
+        return cache.containsKey(key);
+    }
+
+    @Override
+    public void evictData() {
+        cache.clear();
+        maybeNotifyTopic(null, null, null);
+    }
+
+    @Override
+    public void evictData(final Object key) {
+        final Expirable value = cache.remove(key);
+        maybeNotifyTopic(key, null, (value == null) ? null : value.getVersion());
+    }
+
+    @Override
+    public Object get(final Object key, long txTimestamp) {
+        final Expirable value = cache.get(key);
+        return value == null ? null : value.getValue(txTimestamp);
+    }
+
+    @Override
+    public long getElementCountInMemory() {
+        return cache.size();
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public RegionFactory getRegionFactory() {
+        return regionFactory;
+    }
+
+    @Override
+    public long getSizeInMemory() {
+        return 0;
+    }
+
+    @Override
+    public boolean put(final Object key, final Object value, final long txTimestamp, final Object version) {
+        // The calling code has already done the work of checking if any existing cached entry is replaceable.
+        final Value newValue = new Value(version, nextTimestamp(), value);
+        cache.put(key, newValue);
+        return true;
+    }
+
+    @Override
+    public void unlockItem(final Object key, final SoftLock lock) {
+        maybeNotifyTopic(key, null, null);
+    }
+
+    protected Object createMessage(final Object key, final Object value, final Object currentVersion) {
+        return new Invalidation(key, currentVersion);
+    }
+
+    @SuppressWarnings("Duplicates")
+    protected void maybeInvalidate(final Object messageObject) {
+        final Invalidation invalidation = (Invalidation) messageObject;
+        final Object key = invalidation.getKey();
+        if (key == null) {
+            // Invalidate the entire region cache.
+            cache.clear();
+        } else if (versionComparator == null) {
+            // For an unversioned entity or collection we can only invalidate the entry.
+            cache.remove(key);
+        } else {
+            // For versioned entities we can avoid the invalidation if both we and the remote node know the version,
+            // AND our version is definitely equal or higher.  Otherwise, we have to just invalidate our entry.
+            final Expirable value = cache.get(key);
+            if (value != null) {
+                maybeInvalidateVersionedEntity(key, value, invalidation.getVersion());
+            }
+        }
+    }
+
+    @SuppressWarnings("Duplicates")
+    void cleanup() {
+        final int maxSize;
+        final long timeToLive;
+        if (config != null) {
+            maxSize = config.getMaxSizeConfig().getSize();
+            timeToLive = config.getTimeToLiveSeconds() * SEC_TO_MS;
+        } else {
+            maxSize = MAX_SIZE;
+            timeToLive = CacheEnvironment.getDefaultCacheTimeoutInMillis();
+        }
+
+        final boolean limitSize = maxSize > 0 && maxSize != Integer.MAX_VALUE;
+        if (limitSize || timeToLive > 0) {
+            final List<EvictionEntry> entries = searchEvictableEntries(timeToLive, limitSize);
+            final int diff = cache.size() - maxSize;
+            final int evictionRate = calculateEvictionRate(diff, maxSize);
+            if (evictionRate > 0 && entries != null) {
+                evictEntries(entries, evictionRate);
+            }
+        }
+    }
+
+    void maybeNotifyTopic(final Object key, final Object value, final Object version) {
+        if (topic != null) {
+            topic.publish(createMessage(key, value, version));
+        }
+    }
+
+    private int calculateEvictionRate(final int diff, final int maxSize) {
+        return diff >= 0 ? (diff + (int) (maxSize * BASE_EVICTION_RATE)) : 0;
+    }
+
+    private MessageListener<Object> createMessageListener() {
+        return new MessageListener<Object>() {
+
+            @Override
+            public void onMessage(final Message<Object> message) {
+                maybeInvalidate(message.getMessageObject());
+            }
+        };
+    }
+
+    private void evictEntries(final List<EvictionEntry> entries, final int evictionRate) {
+        // Only sort the entries if we're going to evict some
+        Collections.sort(entries);
+        int removed = 0;
+        for (final EvictionEntry entry : entries) {
+            if (cache.remove(entry.key, entry.value) && ++removed == evictionRate) {
+                break;
+            }
+        }
+    }
+
+    private Comparator findVersionComparator(DomainDataRegionConfig regionConfig) {
+        if (regionConfig == null) {
+            return null;
+        }
+        for (final EntityDataCachingConfig entityConfig : regionConfig.getEntityCaching()) {
+            if (entityConfig.isVersioned()) {
+                try {
+                    return entityConfig.getVersionComparatorAccess().get();
+                } catch (Throwable throwable) {
+                    log.warning("Unable to get version comparator", throwable);
+                    return null;
+                }
+            }
+        }
+        for (final CollectionDataCachingConfig collectionConfig : regionConfig.getCollectionCaching()) {
+            if (collectionConfig.isVersioned()) {
+                return collectionConfig.getOwnerVersionComparator();
+            }
+        }
+        return null;
+    }
+
+    @SuppressWarnings("Duplicates")
+    private void maybeInvalidateVersionedEntity(final Object key, final Expirable value, final Object newVersion) {
+        if (newVersion == null) {
+            // This invalidation was for an entity with unknown version.  Just invalidate the entry
+            // unconditionally.
+            cache.remove(key);
+        } else {
+            // Invalidate our entry only if it was of a lower version (we can determine this by checking if the cached
+            // item is writeable).
+            final AbstractReadWriteAccess.Lockable cachedItem = (AbstractReadWriteAccess.Lockable) value.getValue();
+            if (cachedItem.isWriteable(nextTimestamp(), newVersion, versionComparator)) {
+                cache.remove(key, value);
+            }
+        }
+    }
+
+    @SuppressWarnings("Duplicates")
+    private List<EvictionEntry> searchEvictableEntries(final long timeToLive, final boolean limitSize) {
+        List<EvictionEntry> entries = null;
+        final Iterator<Entry<Object, Expirable>> iter = cache.entrySet().iterator();
+        final long now = nextTimestamp();
+        while (iter.hasNext()) {
+            final Entry<Object, Expirable> e = iter.next();
+            final Object k = e.getKey();
+            final Expirable expirable = e.getValue();
+            if (expirable instanceof ExpiryMarker) {
+                continue;
+            }
+            final Value v = (Value) expirable;
+            if (timeToLive > 0 && v.getTimestamp() + timeToLive < now) {
+                iter.remove();
+            } else if (limitSize) {
+                if (entries == null) {
+                    // Use a List rather than a Set for correctness. Using a Set, especially a TreeSet
+                    // based on EvictionEntry.compareTo, causes evictions to be processed incorrectly
+                    // when two or more entries in the map have the same timestamp. In such a case, the
+                    // _first_ entry at a given timestamp is the only one that can be evicted because
+                    // TreeSet does not add "equivalent" entries. A second benefit of using a List is
+                    // that the cost of sorting the entries is not incurred if eviction isn't performed
+                    entries = new ArrayList<>(cache.size());
+                }
+                entries.add(new EvictionEntry(k, v));
+            }
+        }
+        return entries;
+    }
+
+    /**
+     * Inner class that instances represent an entry marked for eviction
+     */
+    private static final class EvictionEntry implements Comparable<EvictionEntry> {
+        final Object key;
+        final Value value;
+
+        private EvictionEntry(final Object key, final Value value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        @Override
+        public int compareTo(final EvictionEntry o) {
+            final long thisVal = this.value.getTimestamp();
+            final long anotherVal = o.value.getTimestamp();
+            return Long.compare(thisVal, anotherVal);
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            EvictionEntry that = (EvictionEntry) o;
+
+            return (key == null ? that.key == null : key.equals(that.key))
+                    && (value == null ? that.value == null : value.equals(that.value));
+        }
+
+        @Override
+        public int hashCode() {
+            return key == null ? 0 : key.hashCode();
+        }
+    }
+}

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/local/LocalRegionCache.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/local/LocalRegionCache.java
@@ -37,7 +37,6 @@ import org.hibernate.cache.spi.access.SoftLock;
 import org.hibernate.cache.spi.support.AbstractReadWriteAccess;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
@@ -242,7 +241,7 @@ public class LocalRegionCache implements RegionCache {
 
     private void evictEntries(final List<EvictionEntry> entries, final int evictionRate) {
         // Only sort the entries if we're going to evict some
-        Collections.sort(entries);
+        entries.sort(null);
         int removed = 0;
         for (final EvictionEntry entry : entries) {
             if (cache.remove(entry.key, entry.value) && ++removed == evictionRate) {

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/local/LocalRegionCache.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/local/LocalRegionCache.java
@@ -135,7 +135,7 @@ public class LocalRegionCache implements RegionCache {
     }
 
     @Override
-    public Object get(final Object key, long txTimestamp) {
+    public Object get(final Object key, final long txTimestamp) {
         final Expirable value = cache.get(key);
         return value == null ? null : value.getValue(txTimestamp);
     }
@@ -251,7 +251,7 @@ public class LocalRegionCache implements RegionCache {
         }
     }
 
-    private Comparator findVersionComparator(DomainDataRegionConfig regionConfig) {
+    private Comparator findVersionComparator(final DomainDataRegionConfig regionConfig) {
         if (regionConfig == null) {
             return null;
         }

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/local/TimestampsRegionCache.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/local/TimestampsRegionCache.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.local;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ITopic;
+import com.hazelcast.core.MessageListener;
+import com.hazelcast.hibernate.RegionCache;
+import com.hazelcast.hibernate.serialization.Expirable;
+import com.hazelcast.hibernate.serialization.Value;
+import org.hibernate.cache.spi.RegionFactory;
+
+/**
+ * A timestamp based local RegionCache
+ */
+public class TimestampsRegionCache extends LocalRegionCache implements RegionCache {
+
+    /**
+     * @param regionFactory     the region factory
+     * @param name              the name for this region cache, which is also used to retrieve configuration/topic
+     * @param hazelcastInstance the {@code HazelcastInstance} to which this region cache belongs, used to retrieve
+     *                          configuration and to lookup an {@link ITopic} to register a {@link MessageListener}
+     *                          with (optional)
+     */
+    public TimestampsRegionCache(final RegionFactory regionFactory, final String name,
+                                 final HazelcastInstance hazelcastInstance) {
+        super(regionFactory, name, hazelcastInstance, null);
+    }
+
+    @Override
+    public void evictData() {
+        cache.clear();
+        maybeNotifyTopic(null, -1L, null);
+    }
+
+    @Override
+    public boolean put(final Object key, final Object value, final long txTimestamp, final Object version) {
+        // use the value in txTimestamp as the timestamp instead of the value, since
+        // hibernate pre-invalidates with a large value, and then invalidates with
+        //the actual time, which can cause queries to not be cached.
+        boolean succeed = super.put(key, value, txTimestamp, version);
+        if (succeed) {
+            maybeNotifyTopic(key, value, version);
+        }
+        return succeed;
+    }
+
+    @Override
+    protected Object createMessage(final Object key, final Object value, final Object currentVersion) {
+        return new Timestamp(key, (Long) value);
+    }
+
+    @SuppressWarnings("Duplicates")
+    @Override
+    protected void maybeInvalidate(final Object messageObject) {
+        final Timestamp ts = (Timestamp) messageObject;
+        final Object key = ts.getKey();
+
+        if (key == null) {
+            // Invalidate the entire region cache.
+            cache.clear();
+            return;
+        }
+
+        for (; ; ) {
+            final Expirable value = cache.get(key);
+            final Long current = value != null ? (Long) value.getValue() : null;
+            if (current != null) {
+                if (ts.getTimestamp() > current) {
+                    if (cache.replace(key, value, new Value(value.getVersion(), nextTimestamp(), ts.getTimestamp()))) {
+                        return;
+                    }
+                } else {
+                    return;
+                }
+            } else {
+                if (cache.putIfAbsent(key, new Value(null, nextTimestamp(), ts.getTimestamp())) == null) {
+                    return;
+                }
+            }
+        }
+    }
+
+    @Override
+    final void cleanup() {
+    }
+}

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/local/package-info.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/local/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides region interfaces/classes for Hibernate.
+ */
+package com.hazelcast.hibernate.local;

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/package-info.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides region interfaces/classes for Hibernate.
+ */
+package com.hazelcast.hibernate;

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/serialization/CacheEntryImpl.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/serialization/CacheEntryImpl.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.serialization;
+
+import org.hibernate.cache.spi.entry.CacheEntry;
+
+import java.io.Serializable;
+
+/**
+ * Simple CacheEntry implementation to avoid using internal Hibernate class StandardCacheEntryImpl
+ */
+public class CacheEntryImpl implements CacheEntry {
+    private final Serializable[] disassembledState;
+    private final String subclass;
+    private final Object version;
+
+    public CacheEntryImpl(final Serializable[] disassembledState, final String subclass, final Object version) {
+        this.disassembledState = disassembledState;
+        this.subclass = subclass;
+        this.version = version;
+    }
+
+    @Override
+    public String getSubclass() {
+        return subclass;
+    }
+
+    @Override
+    public Object getVersion() {
+        return version;
+    }
+
+    @Override
+    public Serializable[] getDisassembledState() {
+        return disassembledState;
+    }
+
+    @Override
+    public boolean isReferenceEntry() {
+        return false;
+    }
+}

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/serialization/Hibernate53CacheEntrySerializer.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/serialization/Hibernate53CacheEntrySerializer.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.serialization;
+
+import com.hazelcast.internal.serialization.impl.SerializationConstants;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.StreamSerializer;
+import org.hibernate.cache.spi.entry.CacheEntry;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+/**
+ * A {@code CacheEntry} serializer compatible with the SPI interface as updated for Hibernate 5.3. For reference
+ * entries the {@code CacheEntry} is serialized directly to avoid relying on too many Hibernate implementation
+ * details. Entity entries (the most common type) are serialized by accessing the fields using the interface's
+ * methods. Note that the {@code areLazyPropertiesUnfetched()} method was removed in 5.1.
+ */
+class Hibernate53CacheEntrySerializer implements StreamSerializer<CacheEntry> {
+    @Override
+    public int getTypeId() {
+        return SerializationConstants.HIBERNATE5_TYPE_HIBERNATE_CACHE_ENTRY;
+    }
+
+    @Override
+    public void destroy() {
+    }
+
+    @SuppressWarnings("Duplicates")
+    @Override
+    public CacheEntry read(final ObjectDataInput in)
+            throws IOException {
+
+        try {
+            if (in.readBoolean()) {
+                return readReference(in);
+            }
+            return readDisassembled(in);
+        } catch (Exception e) {
+            throw rethrow(e);
+        }
+    }
+
+    @SuppressWarnings("Duplicates")
+    @Override
+    public void write(final ObjectDataOutput out, final CacheEntry object)
+            throws IOException {
+
+        try {
+            out.writeBoolean(object.isReferenceEntry());
+            if (object.isReferenceEntry()) {
+                // Reference entries are not disassembled. Instead, to be serialized, they rely entirely on
+                // the entity itself being Serializable. This is not a common thing (Hibernate is currently
+                // very restrictive about what can be cached by reference), so it may not be worth dealing
+                // with at all. This is just a naive implementation relying on the entity's serialization.
+                writeReference(out, object);
+            } else {
+                writeDisassembled(out, object);
+            }
+        } catch (Exception e) {
+            throw rethrow(e);
+        }
+    }
+
+    @SuppressWarnings("Duplicates")
+    private static CacheEntry readDisassembled(final ObjectDataInput in)
+            throws IOException {
+
+        final int length = in.readInt();
+        final Serializable[] disassembledState = new Serializable[length];
+        for (int i = 0; i < length; i++) {
+            disassembledState[i] = in.readObject();
+        }
+
+        final String subclass = in.readUTF();
+        final Object version = in.readObject();
+
+        return new CacheEntryImpl(disassembledState, subclass, version);
+    }
+
+    private static CacheEntry readReference(final ObjectDataInput in) throws IOException {
+        return ((CacheEntryWrapper) in.readObject()).entry;
+    }
+
+    private static IOException rethrow(final Exception e)
+            throws IOException {
+
+        if (e instanceof IOException) {
+            throw (IOException) e;
+        }
+        throw new IOException(e);
+    }
+
+    @SuppressWarnings("Duplicates")
+    private static void writeDisassembled(final ObjectDataOutput out, final CacheEntry object)
+            throws IOException {
+
+        final Serializable[] disassembledState = object.getDisassembledState();
+        out.writeInt(disassembledState.length);
+        for (final Serializable state : disassembledState) {
+            out.writeObject(state);
+        }
+
+        out.writeUTF(object.getSubclass());
+        out.writeObject(object.getVersion());
+    }
+
+    private static void writeReference(final ObjectDataOutput out, final CacheEntry object)
+            throws IOException {
+
+        out.writeObject(new CacheEntryWrapper(object));
+    }
+
+    /**
+     * Wraps a CacheEntry so that serializing it will not recursively call back into this class.
+     * <p/>
+     * {@code CacheEntry} extends {@code Serializable}, so the entry could theoretically just be written with
+     * {@code ObjectDataOutput.writeObject(Object)}. However, doing so would cause the {@code SerializationService}
+     * to look up the serializer and route the entry right back here again, forming an infinite loop. This wrapper
+     * type, which has no explicit mapping, should fall back on the {@code ObjectSerializer} and be serialized by
+     * a standard {@code ObjectOutputStream}.
+     */
+    private static final class CacheEntryWrapper implements Serializable {
+
+        private final CacheEntry entry;
+
+        private CacheEntryWrapper(final CacheEntry entry) {
+            this.entry = entry;
+        }
+    }
+}

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/serialization/Hibernate5CacheEntrySerializerHook.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/serialization/Hibernate5CacheEntrySerializerHook.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.serialization;
+
+import com.hazelcast.nio.serialization.Serializer;
+import com.hazelcast.nio.serialization.SerializerHook;
+
+/**
+ * This class is used to register a special serializer to not lose
+ * power over serialization in Hibernate 5.3.
+ */
+public class Hibernate5CacheEntrySerializerHook implements SerializerHook {
+
+    private final Class<?> cacheEntryClass = CacheEntryImpl.class;
+
+    @Override
+    public Serializer createSerializer() {
+        return new Hibernate53CacheEntrySerializer();
+    }
+
+    @Override
+    public Class getSerializationType() {
+        return cacheEntryClass;
+    }
+
+    @Override
+    public boolean isOverwritable() {
+        return true;
+    }
+}

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/serialization/package-info.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/serialization/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This class contains the Hibernate 5 serializer hooks so that we don't
+ * lose handling on serialization while working on Hibernate.
+ */
+package com.hazelcast.hibernate.serialization;

--- a/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/CacheHitMissNonStrictTest.java
+++ b/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/CacheHitMissNonStrictTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.hibernate.cache.spi.ExtendedStatisticsSupport;
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cache.spi.support.DomainDataRegionTemplate;
+import org.hibernate.cfg.Environment;
+import org.hibernate.internal.SessionFactoryImpl;
+import org.hibernate.stat.CacheRegionStatistics;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Read and write access (non-strict) cache concurrency strategy of Hibernate.
+ * Data may be added, removed and mutated.
+ * Nonstrict means that data integrity is not preserved as strictly as in READ_WRITE access
+ * Cache invalidations are asychrnonous
+ * Read through cache
+ */
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class CacheHitMissNonStrictTest
+        extends HibernateStatisticsTestSupport {
+
+    protected String getCacheStrategy() {
+        return AccessType.NONSTRICT_READ_WRITE.getExternalName();
+    }
+
+    @Override
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        return props;
+    }
+
+    @Test
+    public void testGetUpdateRemoveGet()
+            throws Exception {
+        insertDummyEntities(10, 4);
+        //all 10 entities and 40 properties are cached
+        CacheRegionStatistics dummyEntityCacheStats = sf.getStatistics().getDomainDataRegionStatistics(CACHE_ENTITY);
+        CacheRegionStatistics dummyPropertyCacheStats = sf.getStatistics().getDomainDataRegionStatistics(CACHE_PROPERTY);
+
+        sf.getCache().evictEntityData();
+        sf.getCache().evictCollectionData();
+
+        //miss 10 entities
+        getDummyEntities(sf, 10);
+
+        //hit 1 entity and 4 properties
+        updateDummyEntityName(sf, 2, "updated");
+
+        //entity 2 and its properties are invalidated
+
+        //miss updated entity, hit 4 properties(they are still the same)
+        getPropertiesOfEntity(sf, 2);
+
+        //hit 1 entity and 4 properties
+        deleteDummyEntity(sf, 1);
+
+        assertEquals(12, dummyPropertyCacheStats.getHitCount());
+        assertEquals(0, dummyPropertyCacheStats.getMissCount());
+        assertEquals(2, dummyEntityCacheStats.getHitCount());
+        assertEquals(11, dummyEntityCacheStats.getMissCount());
+    }
+
+    @Test
+    public void testUpdateEventuallyInvalidatesObject() {
+        insertDummyEntities(10, 4);
+        //all 10 entities and 40 properties are cached
+        DomainDataRegionTemplate regionTemplate = (DomainDataRegionTemplate) (((SessionFactoryImpl) sf).getCache()).getRegion(CACHE_ENTITY);
+        ExtendedStatisticsSupport stats = (ExtendedStatisticsSupport) ((HazelcastStorageAccessImpl) regionTemplate.getCacheStorageAccess()).getDelegate();
+
+        sf.getCache().evictEntityData();
+        sf.getCache().evictCollectionData();
+
+        //miss 10 entities
+        getDummyEntities(sf, 10);
+
+        //hit 1 entity and 4 properties
+        updateDummyEntityName(sf, 2, "updated");
+
+        assertTrueEventually(new AssertTask() {
+            public void run() {
+                assertEquals(9, stats.getElementCountInMemory());
+            }
+        });
+    }
+}

--- a/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/CacheHitMissReadOnlyTest.java
+++ b/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/CacheHitMissReadOnlyTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.hibernate.cache.cfg.spi.EntityDataCachingConfig;
+import org.hibernate.cache.spi.DomainDataRegion;
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cache.spi.support.EntityReadOnlyAccess;
+import org.hibernate.cfg.Environment;
+import org.hibernate.stat.CacheRegionStatistics;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Read-only access cache concurrency strategy of Hibernate.
+ * Data may be added and removed, but not mutated.
+ */
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class CacheHitMissReadOnlyTest
+        extends HibernateStatisticsTestSupport {
+
+    protected String getCacheStrategy() {
+        return AccessType.READ_ONLY.getExternalName();
+    }
+
+    @Override
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        return props;
+    }
+
+    @Test
+    public void testGetUpdateRemoveGet()
+            throws Exception {
+        insertDummyEntities(10, 4);
+        //all 10 entities and 40 properties are cached
+        CacheRegionStatistics dummyEntityCacheStats = sf.getStatistics().getDomainDataRegionStatistics(CACHE_ENTITY);
+        CacheRegionStatistics dummyPropertyCacheStats = sf.getStatistics().getDomainDataRegionStatistics(CACHE_PROPERTY);
+
+        sf.getCache().evictEntityData();
+        sf.getCache().evictCollectionData();
+        //miss 10 entities
+        getDummyEntities(sf, 10);
+        //hit 1 entity and 4 properties
+        deleteDummyEntity(sf, 1);
+
+        assertEquals(4, dummyPropertyCacheStats.getHitCount());
+        assertEquals(0, dummyPropertyCacheStats.getMissCount());
+        assertEquals(1, dummyEntityCacheStats.getHitCount());
+        assertEquals(10, dummyEntityCacheStats.getMissCount());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testReadOnlyUpdate() {
+        insertDummyEntities(1, 0);
+        updateDummyEntityName(sf, 0, "updated");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testAfterUpdateShouldThrowOnReadOnly() {
+        DomainDataRegion hzRegion = mock(DomainDataRegion.class);
+        EntityDataCachingConfig config = mock(EntityDataCachingConfig.class);
+        EntityReadOnlyAccess readOnlyAccess = new EntityReadOnlyAccess(hzRegion, null, null, config);
+        readOnlyAccess.afterUpdate(null, null, null, null, null, null);
+    }
+}

--- a/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/CacheHitMissReadWriteTest.java
+++ b/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/CacheHitMissReadWriteTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.hibernate.cache.spi.ExtendedStatisticsSupport;
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cache.spi.support.DomainDataRegionTemplate;
+import org.hibernate.cfg.Environment;
+import org.hibernate.internal.SessionFactoryImpl;
+import org.hibernate.stat.CacheRegionStatistics;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Read and write access (strict) cache concurrency strategy of Hibernate.
+ * Data may be added, removed and mutated.
+ * Strict means data integrity is preserved strictly (by locks)
+ * Write through cache
+ */
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class CacheHitMissReadWriteTest
+        extends HibernateStatisticsTestSupport {
+
+    protected String getCacheStrategy() {
+        return AccessType.READ_WRITE.getExternalName();
+    }
+
+    @Override
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        return props;
+    }
+
+    @Test
+    public void testGetUpdateRemoveGet()
+            throws Exception {
+        insertDummyEntities(10, 4);
+        //all 10 entities and 40 properties are cached
+        CacheRegionStatistics dummyEntityCacheStats = sf.getStatistics().getDomainDataRegionStatistics(CACHE_ENTITY);
+        CacheRegionStatistics dummyPropertyCacheStats = sf.getStatistics().getDomainDataRegionStatistics(CACHE_PROPERTY);
+
+        sf.getCache().evictEntityData();
+        sf.getCache().evictCollectionData();
+
+        //miss 10 entities
+        getDummyEntities(sf, 10);
+
+        //hit 1 entity and 4 properties
+        updateDummyEntityName(sf, 2, "updated");
+
+        //hit 1 entity, hit 4 properties
+        getPropertiesOfEntity(sf, 2);
+        //hit 1 entity and 4 properties
+        deleteDummyEntity(sf, 1);
+
+        assertEquals(12, dummyPropertyCacheStats.getHitCount());
+        assertEquals(0, dummyPropertyCacheStats.getMissCount());
+        assertEquals(3, dummyEntityCacheStats.getHitCount());
+        assertEquals(10, dummyEntityCacheStats.getMissCount());
+
+    }
+
+    @Test
+    public void testUpdateShouldInvalidateEntryInCache() {
+        insertDummyEntities(10, 4);
+        //all 10 entities and 40 properties are cached
+        DomainDataRegionTemplate regionTemplate = (DomainDataRegionTemplate) (((SessionFactoryImpl) sf).getCache()).getRegion(CACHE_ENTITY);
+        ExtendedStatisticsSupport stats = ((HazelcastStorageAccessImpl) regionTemplate.getCacheStorageAccess()).getDelegate();
+
+        sf.getCache().evictEntityData();
+        sf.getCache().evictCollectionData();
+
+        //miss 10 entities, 10 entities are cached
+        getDummyEntities(sf, 10);
+
+        //updates cache entity
+        updateDummyEntityName(sf, 2, "updated");
+
+        assertEquals(10, stats.getElementCountInMemory());
+    }
+}

--- a/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/CustomPropertiesTest.java
+++ b/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/CustomPropertiesTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.HazelcastClientProxy;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.ClasspathXmlConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.hibernate.instance.HazelcastAccessor;
+import com.hazelcast.hibernate.instance.HazelcastMockInstanceLoader;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.SlowTest;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
+import org.hibernate.internal.SessionFactoryImpl;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.util.Date;
+import java.util.Properties;
+
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.isA;
+import static org.junit.Assert.*;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
+public class CustomPropertiesTest extends HibernateTestSupport {
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    @SuppressWarnings("Duplicates")
+    @Test
+    public void testNativeClient() {
+        TestHazelcastFactory factory = new TestHazelcastFactory();
+        Config config = new ClasspathXmlConfig("hazelcast-custom.xml");
+        HazelcastInstance main = factory.newHazelcastInstance(config);
+        Properties props = getDefaultProperties();
+        props.remove(CacheEnvironment.CONFIG_FILE_PATH_LEGACY);
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        props.setProperty(CacheEnvironment.USE_NATIVE_CLIENT, "true");
+        props.setProperty(CacheEnvironment.NATIVE_CLIENT_GROUP, "dev-custom");
+        props.setProperty(CacheEnvironment.NATIVE_CLIENT_PASSWORD, "dev-pass");
+        props.setProperty(CacheEnvironment.CONFIG_FILE_PATH,"hazelcast-client-custom.xml");
+        HazelcastMockInstanceLoader loader = new HazelcastMockInstanceLoader();
+        loader.configure(props);
+        loader.setInstanceFactory(factory);
+        SessionFactory sf = createSessionFactory(props, loader);
+        final HazelcastInstance hz = HazelcastAccessor.getHazelcastInstance(sf);
+        assertTrue(hz instanceof HazelcastClientProxy);
+        assertEquals(1, main.getCluster().getMembers().size());
+        HazelcastClientProxy client = (HazelcastClientProxy) hz;
+        ClientConfig clientConfig = client.getClientConfig();
+        assertEquals("dev-custom", clientConfig.getGroupConfig().getName());
+        assertEquals("dev-pass", clientConfig.getGroupConfig().getPassword());
+        assertTrue(clientConfig.getNetworkConfig().isSmartRouting());
+        assertTrue(clientConfig.getNetworkConfig().isRedoOperation());
+        factory.newHazelcastInstance(config);
+        assertEquals(2, hz.getCluster().getMembers().size());
+        main.shutdown();
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(1, hz.getCluster().getMembers().size());
+            }
+        });
+
+        assertEquals(1, hz.getCluster().getMembers().size());
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        session.save(new DummyEntity(1L, "dummy", 0, new Date()));
+        tx.commit();
+        session.close();
+        sf.close();
+        factory.shutdownAll();
+    }
+
+    @SuppressWarnings("Duplicates")
+    @Test
+    public void testNamedInstance() {
+        TestHazelcastFactory factory = new TestHazelcastFactory();
+        Config config = new Config();
+        config.setInstanceName("hibernate");
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        props.put(CacheEnvironment.HAZELCAST_INSTANCE_NAME, "hibernate");
+        props.put(CacheEnvironment.SHUTDOWN_ON_STOP, "false");
+        props.setProperty("hibernate.dialect", "org.hibernate.dialect.HSQLDialect");
+
+        Configuration configuration = new Configuration();
+        configuration.addProperties(props);
+
+        SessionFactory sf = configuration.buildSessionFactory();
+        assertEquals(hz, HazelcastAccessor.getHazelcastInstance(sf));
+        sf.close();
+        assertTrue(hz.getLifecycleService().isRunning());
+        factory.shutdownAll();
+    }
+
+    @Test
+    public void testNamedInstance_noInstance() {
+        exception.expect(IllegalStateException.class);
+        exception.expectCause(allOf(isA(CacheException.class), new BaseMatcher<CacheException>() {
+            @Override
+            public boolean matches(Object item) {
+                return ((CacheException) item).getMessage().contains("No instance with name [hibernate] could be found.");
+            }
+
+            @Override
+            public void describeTo(Description description) {
+            }
+        }));
+
+        Config config = new Config();
+        config.setInstanceName("hibernate");
+
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        props.put(CacheEnvironment.HAZELCAST_INSTANCE_NAME, "hibernate");
+        props.put(CacheEnvironment.SHUTDOWN_ON_STOP, "false");
+        props.setProperty("hibernate.dialect", "org.hibernate.dialect.HSQLDialect");
+
+        Configuration configuration = new Configuration();
+        configuration.addProperties(props);
+
+        SessionFactory sf = configuration.buildSessionFactory();
+        AbstractHazelcastCacheRegionFactory hazelcastRegionFactory = (AbstractHazelcastCacheRegionFactory) ((SessionFactoryImpl) sf).getCache().getRegionFactory();
+        hazelcastRegionFactory.isStarted();
+        sf.close();
+    }
+
+    @Test
+    public void testNamedClient_noInstance() {
+        exception.expect(IllegalStateException.class);
+        exception.expectCause(allOf(isA(CacheException.class), new BaseMatcher<CacheException>() {
+            @Override
+            public boolean matches(Object item) {
+                return ((CacheException) item).getMessage().contains("No client with name [dev-custom] could be found.");
+            }
+
+            @Override
+            public void describeTo(Description description) {
+            }
+        }));
+
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        props.setProperty(CacheEnvironment.USE_NATIVE_CLIENT, "true");
+        props.setProperty(CacheEnvironment.NATIVE_CLIENT_INSTANCE_NAME, "dev-custom");
+        props.setProperty("hibernate.dialect", "org.hibernate.dialect.HSQLDialect");
+
+        Configuration configuration = new Configuration();
+        configuration.addProperties(props);
+
+        SessionFactory sf = configuration.buildSessionFactory();
+        AbstractHazelcastCacheRegionFactory hazelcastRegionFactory = (AbstractHazelcastCacheRegionFactory) ((SessionFactoryImpl) sf).getCache().getRegionFactory();
+        hazelcastRegionFactory.isStarted();
+        sf.close();
+    }
+
+    @SuppressWarnings("Duplicates")
+    @Test
+    public void testHazelcastAccessorReturnsNullIfSecondLevelCacheIsNotHazelcast() {
+        Properties props = new Properties();
+        props.setProperty("hibernate.dialect", "org.hibernate.dialect.HSQLDialect");
+
+        Configuration configuration = new Configuration();
+        configuration.addProperties(props);
+        SessionFactory sf = configuration.buildSessionFactory();
+
+        assertNull(HazelcastAccessor.getHazelcastInstance(sf));
+
+        sf.close();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testWrongHazelcastConfigurationFilePathShouldThrow() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        props.setProperty("hibernate.dialect", "org.hibernate.dialect.HSQLDialect");
+
+        //we give a non-exist config file address, should fail fast
+        props.setProperty("hibernate.cache.hazelcast.configuration_file_path", "non-exist.xml");
+
+        Configuration configuration = new Configuration();
+        configuration.addProperties(props);
+        SessionFactory sf = configuration.buildSessionFactory();
+        AbstractHazelcastCacheRegionFactory hazelcastRegionFactory = (AbstractHazelcastCacheRegionFactory) ((SessionFactoryImpl) sf).getCache().getRegionFactory();
+        hazelcastRegionFactory.isStarted();
+        sf.close();
+    }
+
+    private Properties getDefaultProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        props.setProperty(CacheEnvironment.CONFIG_FILE_PATH_LEGACY, "hazelcast-custom.xml");
+        return props;
+    }
+}

--- a/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/NaturalIdTest.java
+++ b/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/NaturalIdTest.java
@@ -1,0 +1,140 @@
+package com.hazelcast.hibernate;
+
+import com.hazelcast.hibernate.entity.AnnotatedEntity;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.SlowTest;
+import org.hibernate.Criteria;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cfg.Environment;
+import org.hibernate.criterion.Restrictions;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category(SlowTest.class)
+public class NaturalIdTest extends HibernateStatisticsTestSupport {
+
+    @Parameterized.Parameters(name = "Executing: {0}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[]{AccessType.READ_WRITE},
+                new Object[]{AccessType.READ_ONLY},
+                new Object[]{AccessType.NONSTRICT_READ_WRITE}
+        );
+    }
+
+    @Parameterized.Parameter(0)
+    public AccessType defaultAccessType;
+
+    @Override
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.put("TestAccessType", defaultAccessType);
+        props.setProperty(Environment.CACHE_REGION_FACTORY, InternalMockRegionFactory.class.getName());
+        return props;
+    }
+
+    @SuppressWarnings("Duplicates")
+    @Test
+    public void testNaturalIdCacheEvictsEntityOnUpdate() {
+        Assume.assumeTrue(defaultAccessType == AccessType.READ_WRITE);
+
+        insertAnnotatedEntities(1);
+
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+
+        //1 cache hit since dummy:0 just inserted and still in the cache
+        AnnotatedEntity toBeUpdated = session.byNaturalId(AnnotatedEntity.class).using("title", "dummy:0").getReference();
+        toBeUpdated.setTitle("dummy101");
+        tx.commit();
+        session.close();
+
+        assertEquals(1, sf.getStatistics().getNaturalIdCacheHitCount());
+
+        //dummy:0 should be evicted and this leads to a cache miss
+        session = sf.openSession();
+        Criteria criteria = session.createCriteria(AnnotatedEntity.class).add(Restrictions.naturalId().set("title","dummy:0"))
+                                   .setCacheable(true);
+        criteria.uniqueResult();
+
+        assertEquals(1, sf.getStatistics().getNaturalIdCacheMissCount());
+    }
+
+    @SuppressWarnings("Duplicates")
+    @Test
+    public void testNaturalIdCacheStillHitsAfterIrrelevantNaturalIdUpdate() {
+        Assume.assumeTrue(defaultAccessType == AccessType.READ_WRITE);
+
+        insertAnnotatedEntities(2);
+
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+
+        //1 cache hit since dummy:1 just inserted and still in the cache
+        AnnotatedEntity toBeUpdated = session.byNaturalId(AnnotatedEntity.class).using("title", "dummy:1").getReference();
+        toBeUpdated.setTitle("dummy101");
+        tx.commit();
+        session.close();
+
+        assertEquals(1, sf.getStatistics().getNaturalIdCacheHitCount());
+
+        //only dummy:1 should be evicted from cache on contrary to behavior of hibernate query cache without natural ids
+        session = sf.openSession();
+        Criteria criteria = session.createCriteria(AnnotatedEntity.class).add(Restrictions.naturalId().set("title","dummy:0"))
+                                   .setCacheable(true);
+        criteria.uniqueResult();
+
+        //cache hit dummy:0 + previous hit
+        assertEquals(2, sf.getStatistics().getNaturalIdCacheHitCount());
+    }
+
+    @SuppressWarnings("Duplicates")
+    @Test
+    public void testFindByNaturalId() {
+        insertAnnotatedEntities(1);
+        Session session = sf.openSession();
+
+        AnnotatedEntity toBeUpdated = session.byNaturalId(AnnotatedEntity.class).using("title", "dummy:0").getReference();
+        assertEquals("dummy:0", toBeUpdated.getTitle());
+        session.close();
+    }
+
+    @Test
+    public void testEvictionNaturalId() {
+        insertAnnotatedEntities(1);
+        sf.getCache().evictNaturalIdRegion(AnnotatedEntity.class);
+        assertFalse(sf.getCache().containsEntity(AnnotatedEntity.class, 0L));
+    }
+
+    public static class InternalMockRegionFactory
+            extends HazelcastCacheRegionFactory {
+
+        private AccessType defaultAccessType;
+
+        public InternalMockRegionFactory() {
+            super();
+        }
+
+        public InternalMockRegionFactory(final Properties properties) {
+            defaultAccessType = (AccessType) properties.get("TestAccessType");
+        }
+
+        @Override
+        public AccessType getDefaultAccessType() {
+            return defaultAccessType;
+        }
+    }
+}

--- a/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultSlowTest.java
+++ b/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultSlowTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.SlowTest;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.cache.spi.support.QueryResultsRegionTemplate;
+import org.hibernate.cfg.Environment;
+import org.hibernate.internal.SessionFactoryImpl;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
+public class RegionFactoryDefaultSlowTest
+        extends HibernateSlowTestSupport {
+
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        return props;
+    }
+
+    @Test
+    public void testQueryCacheCleanup() {
+        MapConfig mapConfig = getHazelcastInstance(sf).getConfig().getMapConfig("default-query-results-region");
+        final float baseEvictionRate = 0.2f;
+        final int numberOfEntities = 100;
+        final int defaultCleanupPeriod = 60;
+        final int maxSize = mapConfig.getMaxSizeConfig().getSize();
+        final int evictedItemCount = numberOfEntities - maxSize + (int) (maxSize * baseEvictionRate);
+        insertDummyEntities(numberOfEntities);
+        for (int i = 0; i < numberOfEntities; i++) {
+            executeQuery(sf, i);
+        }
+
+        QueryResultsRegionTemplate regionTemplate = (QueryResultsRegionTemplate) (((SessionFactoryImpl) sf).getCache()).getDefaultQueryResultsCache().getRegion();
+        RegionCache cache = ((HazelcastStorageAccessImpl) regionTemplate.getStorageAccess()).getDelegate();
+        assertEquals(numberOfEntities, cache.getElementCountInMemory());
+        sleep(defaultCleanupPeriod);
+
+        assertEquals(numberOfEntities - evictedItemCount, cache.getElementCountInMemory());
+    }
+
+    @SuppressWarnings("Duplicates")
+    @Test
+    public void testUpdateEntity() {
+        final long dummyId = 0;
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        session.save(new DummyEntity(dummyId, null, 0, null));
+        tx.commit();
+
+        tx = session.beginTransaction();
+        DummyEntity ent = session.get(DummyEntity.class, dummyId);
+        ent.setName("updatedName");
+        session.update(ent);
+        tx.commit();
+        session.close();
+
+        session = sf2.openSession();
+        DummyEntity entity = session.get(DummyEntity.class, dummyId);
+        assertEquals("updatedName", entity.getName());
+    }
+}

--- a/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/local/LocalRegionCacheTest.java
+++ b/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/local/LocalRegionCacheTest.java
@@ -1,0 +1,141 @@
+package com.hazelcast.hibernate.local;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ITopic;
+import com.hazelcast.core.MessageListener;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.hibernate.cache.cfg.spi.CollectionDataCachingConfig;
+import org.hibernate.cache.cfg.spi.DomainDataRegionConfig;
+import org.hibernate.cache.cfg.spi.EntityDataCachingConfig;
+import org.hibernate.cache.spi.RegionFactory;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.function.Supplier;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+@SuppressWarnings("unchecked")
+public class LocalRegionCacheTest {
+
+    private static final String CACHE_NAME = "cache";
+
+    @Mock
+    private RegionFactory regionFactory;
+
+    @Test
+    public void testConstructorIgnoresUnsupportedOperationExceptionsFromConfig() {
+        HazelcastInstance instance = mock(HazelcastInstance.class);
+        doThrow(UnsupportedOperationException.class).when(instance).getConfig();
+
+        new LocalRegionCache(regionFactory, CACHE_NAME, instance, null, false);
+    }
+
+    @Test
+    public void testConstructorIgnoresVersionComparatorForUnversionedEntityData() {
+        DomainDataRegionConfig domainDataRegionConfig = mock(DomainDataRegionConfig.class);
+        EntityDataCachingConfig entityDataCachingConfig = mock(EntityDataCachingConfig.class);
+        when(domainDataRegionConfig.getEntityCaching()).thenReturn(Collections.singletonList(entityDataCachingConfig));
+        doThrow(AssertionError.class).when(entityDataCachingConfig).getVersionComparatorAccess(); // Will fail the test if called
+
+        new LocalRegionCache(regionFactory, CACHE_NAME, null, domainDataRegionConfig, false);
+        verify(entityDataCachingConfig).isVersioned(); // Verify that the versioned flag was checked
+        verifyNoMoreInteractions(entityDataCachingConfig);
+    }
+
+    @Test
+    public void testConstructorSetsVersionComparatorForVersionedEntityData() {
+        Comparator<?> comparator = mock(Comparator.class);
+
+        DomainDataRegionConfig domainDataRegionConfig = mock(DomainDataRegionConfig.class);
+        EntityDataCachingConfig entityDataCachingConfig = mock(EntityDataCachingConfig.class);
+        when(domainDataRegionConfig.getEntityCaching()).thenReturn(Collections.singletonList(entityDataCachingConfig));
+        when(entityDataCachingConfig.isVersioned()).thenReturn(true);
+        Supplier x = () -> comparator;
+        when(entityDataCachingConfig.getVersionComparatorAccess()).thenReturn(x);
+
+        new LocalRegionCache(regionFactory, CACHE_NAME, null, domainDataRegionConfig, false);
+        verify(entityDataCachingConfig).isVersioned();
+        verify(entityDataCachingConfig).getVersionComparatorAccess();
+    }
+
+    @Test
+    public void testConstructorIgnoresVersionComparatorForUnversionedCollectionData() {
+        DomainDataRegionConfig domainDataRegionConfig = mock(DomainDataRegionConfig.class);
+        CollectionDataCachingConfig collectionDataCachingConfig = mock(CollectionDataCachingConfig.class);
+        when(domainDataRegionConfig.getCollectionCaching()).thenReturn(Collections.singletonList(collectionDataCachingConfig));
+        doThrow(AssertionError.class).when(collectionDataCachingConfig).getOwnerVersionComparator(); // Will fail the test if called
+
+        new LocalRegionCache(regionFactory, CACHE_NAME, null, domainDataRegionConfig, false);
+        verify(collectionDataCachingConfig).isVersioned(); // Verify that the versioned flag was checked
+        verifyNoMoreInteractions(collectionDataCachingConfig);
+    }
+
+    @Test
+    public void testConstructorSetsVersionComparatorForVersionedCollectionData() {
+        Comparator<?> comparator = mock(Comparator.class);
+
+        DomainDataRegionConfig domainDataRegionConfig = mock(DomainDataRegionConfig.class);
+        CollectionDataCachingConfig collectionDataCachingConfig = mock(CollectionDataCachingConfig.class);
+        when(domainDataRegionConfig.getCollectionCaching()).thenReturn(Collections.singletonList(collectionDataCachingConfig));
+        when(collectionDataCachingConfig.isVersioned()).thenReturn(true);
+        when(collectionDataCachingConfig.getOwnerVersionComparator()).thenReturn(comparator);
+
+        new LocalRegionCache(regionFactory, CACHE_NAME, null, domainDataRegionConfig, false);
+        verify(collectionDataCachingConfig).getOwnerVersionComparator();
+        verify(collectionDataCachingConfig).isVersioned();
+    }
+
+    @Test
+    public void testFourArgConstructorDoesNotRegisterTopicListenerIfNotRequested() {
+        MapConfig mapConfig = mock(MapConfig.class);
+
+        Config config = mock(Config.class);
+        when(config.findMapConfig(eq(CACHE_NAME))).thenReturn(mapConfig);
+
+        HazelcastInstance instance = mock(HazelcastInstance.class);
+        when(instance.getConfig()).thenReturn(config);
+
+        new LocalRegionCache(regionFactory, CACHE_NAME, instance, null, false);
+        verify(config).findMapConfig(eq(CACHE_NAME));
+        verify(instance).getConfig();
+        verify(instance, never()).getTopic(anyString());
+    }
+
+    // Verifies that the three-argument constructor still registers a listener with a topic if the HazelcastInstance
+    // is provided. This ensures the old behavior has not been regressed by adding the new four argument constructor
+    @Test
+    public void testThreeArgConstructorRegistersTopicListener() {
+        MapConfig mapConfig = mock(MapConfig.class);
+
+        Config config = mock(Config.class);
+        when(config.findMapConfig(eq(CACHE_NAME))).thenReturn(mapConfig);
+
+        ITopic<Object> topic = mock(ITopic.class);
+        when(topic.addMessageListener(isNotNull(MessageListener.class))).thenReturn("ignored");
+
+        HazelcastInstance instance = mock(HazelcastInstance.class);
+        when(instance.getConfig()).thenReturn(config);
+        when(instance.getTopic(eq(CACHE_NAME))).thenReturn(topic);
+
+        new LocalRegionCache(regionFactory, CACHE_NAME, instance, null, true);
+        verify(config).findMapConfig(eq(CACHE_NAME));
+        verify(instance).getConfig();
+        verify(instance).getTopic(eq(CACHE_NAME));
+        verify(topic).addMessageListener(isNotNull(MessageListener.class));
+    }
+
+    @SuppressWarnings("unused")
+    public static void runCleanup(LocalRegionCache cache) {
+        cache.cleanup();
+    }
+}

--- a/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/local/TimestampsRegionCacheTest.java
+++ b/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/local/TimestampsRegionCacheTest.java
@@ -1,0 +1,89 @@
+package com.hazelcast.hibernate.local;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.*;
+import org.hibernate.cache.spi.RegionFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TimestampsRegionCacheTest {
+
+    private static final String CACHE_NAME = "cache";
+
+    @Mock private Config config;
+    @Mock private MapConfig mapConfig;
+    @Mock private ITopic<Object> topic;
+    @Mock private HazelcastInstance instance;
+    @Mock private Cluster cluster;
+    @Mock private Member member;
+    @Mock private RegionFactory regionFactory;
+
+    private TimestampsRegionCache target;
+    private MessageListener<Object> listener;
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Before
+    public void setup() {
+        when(config.findMapConfig(eq(CACHE_NAME))).thenReturn(mapConfig);
+        when(instance.getCluster()).thenReturn(cluster);
+        when(instance.getConfig()).thenReturn(config);
+        when(instance.getTopic(eq(CACHE_NAME))).thenReturn(topic);
+
+        // make the message appear that it is coming from a different member of the cluster
+        when(member.localMember()).thenReturn(false);
+
+        ArgumentCaptor<MessageListener> listener = ArgumentCaptor.forClass(MessageListener.class);
+        when(topic.addMessageListener(listener.capture())).thenReturn("ignored");
+        target = new TimestampsRegionCache(regionFactory, CACHE_NAME, instance);
+        this.listener = listener.getValue();
+    }
+
+    @SuppressWarnings("Duplicates")
+    @Test
+    public void shouldUseClusterTimestampFromInvalidationmessageInsteadOfSystemTime() {
+        long firstTimestamp = 1;
+        long secondTimestamp = 2;
+        long publishTime = 3;
+        long clusterTime = 4;
+
+        when(cluster.getClusterTime()).thenReturn(firstTimestamp, secondTimestamp);
+
+        // cache is primed by call, that uses clusterTime instead of system clock for timestamp
+        assertThat(target.put("QuerySpace", firstTimestamp, firstTimestamp, null), is(true));
+
+        assertThat("primed value should be in the cache", (Long) target.get("QuerySpace", firstTimestamp), is(firstTimestamp));
+
+        // a message is generated on a different cluster member informing us to update the timestamp region cache
+        Message<Object> message = new Message<Object>("topicName", new Timestamp("QuerySpace", secondTimestamp), publishTime, member);
+
+        // process the timestamp region update
+        listener.onMessage(message);
+
+        // this fails if we use system time instead of cluster time, causing the value to stay invisible until clustertime == system time (which it often isn't)
+        assertThat("key should be visible and have value specified in timestamp message, with current cluster time.", (Long) target.get("QuerySpace", clusterTime), is(secondTimestamp));
+    }
+
+    @SuppressWarnings("Duplicates")
+    @Test
+    public void clearCache() {
+        long aTimestamp = 1;
+        assertThat(target.put("QuerySpace", aTimestamp, aTimestamp, null), is(true));
+        assertThat("value should be in the cache", (Long) target.get("QuerySpace", aTimestamp), is(aTimestamp));
+
+        target.clear();
+
+        assertThat("value should not be in the cache", target.get("QuerySpace", aTimestamp), nullValue());
+    }    
+}

--- a/hazelcast-hibernate53/src/test/resources/hazelcast-custom.xml
+++ b/hazelcast-hibernate53/src/test/resources/hazelcast-custom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-3.4.xsd">
+    <group>
+        <name>dev-custom</name>
+        <password>dev-pass</password>
+    </group>
+    <network>
+        <port auto-increment="true">5701</port>
+        <join>
+            <multicast enabled="false">
+                <multicast-group>224.2.2.3</multicast-group>
+                <multicast-port>54327</multicast-port>
+            </multicast>
+            <tcp-ip enabled="true">
+                <interface>127.0.0.1</interface>
+            </tcp-ip>
+        </join>
+        <interfaces enabled="false">
+            <interface>10.3.17.*</interface>
+        </interfaces>
+    </network>
+    <map name="default">
+        <!--
+            Number of backups. If 1 is set as the backup-count for example,
+            then all entries of the map will be copied to another JVM for
+            fail-safety. Valid numbers are 0 (no backup), 1, 2, 3.
+        -->
+        <backup-count>1</backup-count>
+        <!--
+            Valid values are:
+            NONE (no eviction),
+            LRU (Least Recently Used),
+            LFU (Least Frequiently Used).
+            NONE is the default.
+        -->
+        <eviction-policy>NONE</eviction-policy>
+        <!--
+            Maximum size of the map. When max size is reached,
+            map is evicted based on the policy defined.
+            Any integer between 0 and Integer.MAX_VALUE. 0 means
+            Integer.MAX_VALUE. Default is 0.
+        -->
+        <max-size>0</max-size>
+        <!--
+            When max. size is reached, specified percentage of
+            the map will be evicted. Any integer between 0 and 100.
+            If 25 is set for example, 25% of the entries will
+            get evicted.
+        -->
+        <eviction-percentage>25</eviction-percentage>
+    </map>
+
+    <!-- Config for query cache -->
+    <map name="default-query-results-region">
+        <time-to-live-seconds>0</time-to-live-seconds>
+        <max-size>50</max-size>
+    </map>
+</hazelcast>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <name>hazelcast-hibernate5</name>
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast-hibernate5-parent</artifactId>
-    <version>1.2.4-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>Hazelcast In-Memory DataGrid Hibernate Plugin</description>
     <url>http://www.hazelcast.com/</url>
@@ -26,6 +26,7 @@
     <modules>
         <module>hazelcast-hibernate5</module>
         <module>hazelcast-hibernate52</module>
+        <module>hazelcast-hibernate53</module>
     </modules>
 
     <properties>
@@ -61,7 +62,7 @@
         <maven.surefire.plugin.version>2.18.1</maven.surefire.plugin.version>
         <maven.failsafe.plugin.version>2.14</maven.failsafe.plugin.version>
         <maven.findbugs.plugin.version>3.0.0</maven.findbugs.plugin.version>
-        <maven.checkstyle.plugin.version>2.12</maven.checkstyle.plugin.version>
+        <maven.checkstyle.plugin.version>2.15</maven.checkstyle.plugin.version>
         <maven.sonar.plugin.version>3.3.0.603</maven.sonar.plugin.version>
         <maven.jacoco.plugin.version>0.7.9</maven.jacoco.plugin.version>
         <maven.cobertura.plugin.version>2.0</maven.cobertura.plugin.version>
@@ -131,30 +132,6 @@
                 </configuration>
             </plugin>
 
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>${maven.animal.sniffer.plugin.version}</version>
-                <configuration>
-                    <signature>
-                        <groupId>org.codehaus.mojo.signature</groupId>
-                        <artifactId>java16</artifactId>
-                        <version>1.0</version>
-                    </signature>
-                    <ignores>
-                        <ignore>sun.misc.Unsafe</ignore>
-                    </ignores>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>source-java6-check</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>


### PR DESCRIPTION
Implements issue #44 by adding a new module, "hazelcast-hibernate53", which adds support for Hibernate 5.3.x:
* the implementation follows the pattern described in the comment [here](https://github.com/hibernate/hibernate-orm/blob/79a8f43ba57d9e4a1269c5027dfd063b18d4f7d9/hibernate-core/src/main/java/org/hibernate/cache/spi/support/DomainDataRegionTemplate.java#L25)
* changed "hazelcast-hibernate52" to be Java 8 only (as Hibernate 5.2+ requires Java 8)
* bumped version number to 1.3.0-SNAPSHOT
* upgraded maven checkstyle plugin to 2.15, for support for Java 8 syntax