### PR TITLE
Remove 1 network round-trip when putting a value into cache

### DIFF
--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/distributed/IMapRegionCache.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/distributed/IMapRegionCache.java
@@ -94,8 +94,8 @@ public class IMapRegionCache implements RegionCache {
         // the lock was released under heavy load or after network partitions. Hence this implementation now uses
         // a spin loop around atomic operations.
         long timeout = System.currentTimeMillis() + tryLockAndGetTimeout;
+        Value newValue = new Value(version, txTimestamp, value);
         do {
-            Value newValue = new Value(version, txTimestamp, value);
             Expirable previousEntry = map.putIfAbsent(key, newValue);
             if (previousEntry == null) {
                 return true;

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/distributed/IMapRegionCache.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/distributed/IMapRegionCache.java
@@ -99,12 +99,10 @@ public class IMapRegionCache implements RegionCache {
             Expirable previousEntry = map.putIfAbsent(key, newValue);
             if (previousEntry == null) {
                 return true;
-            } else if (previousEntry.isReplaceableBy(txTimestamp, version, versionComparator)) {
-                if (map.replace(key, previousEntry, newValue)) {
-                    return true;
-                }
-            } else {
+            } else if (!previousEntry.isReplaceableBy(txTimestamp, version, versionComparator)) {
                 return false;
+            } else if (map.replace(key, previousEntry, newValue)) {
+                return true;
             }
         } while (System.currentTimeMillis() < timeout);
 

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/distributed/IMapRegionCache.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/distributed/IMapRegionCache.java
@@ -95,12 +95,10 @@ public class IMapRegionCache implements RegionCache {
         // a spin loop around atomic operations.
         long timeout = System.currentTimeMillis() + tryLockAndGetTimeout;
         do {
-            Expirable previousEntry = map.get(key);
             Value newValue = new Value(version, txTimestamp, value);
+            Expirable previousEntry = map.putIfAbsent(key, newValue);
             if (previousEntry == null) {
-                if (map.putIfAbsent(key, newValue) == null) {
-                    return true;
-                }
+                return true;
             } else if (previousEntry.isReplaceableBy(txTimestamp, version, versionComparator)) {
                 if (map.replace(key, previousEntry, newValue)) {
                     return true;


### PR DESCRIPTION
This shouldnt cause any behaviour change except eliminating
one round-trip in the happy-case when the key is not in the map.