### PR TITLE
Fix for #55 - entries evicted too quickly when ttl is greater than zero

### DIFF
--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/local/CleanupService.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/local/CleanupService.java
@@ -32,7 +32,7 @@ public final class CleanupService {
     /**
      * Default fixed delay in seconds for scheduled job.
      */
-    private static final long DEFAULT_FIXED_DELAY = 60;
+    private static final long DEFAULT_FIXED_DELAY = 60L;
 
     private final long fixedDelay;
     private final String name;

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/local/CleanupService.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/local/CleanupService.java
@@ -31,9 +31,8 @@ public final class CleanupService {
 
     /**
      * Default fixed delay in seconds for scheduled job.
-     * Visible for testing.
      */
-    public static final long DEFAULT_FIXED_DELAY = 60;
+    private static final long DEFAULT_FIXED_DELAY = 60;
 
     private final long fixedDelay;
     private final String name;
@@ -43,6 +42,9 @@ public final class CleanupService {
         this(name, DEFAULT_FIXED_DELAY);
     }
 
+    /**
+     * Visible for testing only.
+     */
     public CleanupService(final String name, final long fixedDelay) {
         this.fixedDelay = fixedDelay;
         this.name = name;

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/local/CleanupService.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/local/CleanupService.java
@@ -29,13 +29,22 @@ import java.util.concurrent.TimeUnit;
  */
 public final class CleanupService {
 
-    private static final long FIXED_DELAY = 60;
-    private static final long FIXED_DELAY1 = 60;
+    /**
+     * Default fixed delay in seconds for scheduled job.
+     * Visible for testing.
+     */
+    public static final long DEFAULT_FIXED_DELAY = 60;
 
+    private final long fixedDelay;
     private final String name;
     private final ScheduledExecutorService executor;
 
     public CleanupService(final String name) {
+        this(name, DEFAULT_FIXED_DELAY);
+    }
+
+    public CleanupService(final String name, final long fixedDelay) {
+        this.fixedDelay = fixedDelay;
         this.name = name;
         executor = Executors.newSingleThreadScheduledExecutor(new CleanupThreadFactory());
     }
@@ -47,7 +56,7 @@ public final class CleanupService {
             public void run() {
                 cache.cleanup();
             }
-        }, FIXED_DELAY, FIXED_DELAY1, TimeUnit.SECONDS);
+        }, fixedDelay, fixedDelay, TimeUnit.SECONDS);
     }
 
     public void stop() {

--- a/hazelcast-hibernate53/pom.xml
+++ b/hazelcast-hibernate53/pom.xml
@@ -58,7 +58,6 @@
                                         <exclude>com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java</exclude>
                                         <exclude>com/hazelcast/hibernate/HazelcastCacheRegionFactory.java</exclude>
                                         <exclude>com/hazelcast/hibernate/HazelcastLocalCacheRegionFactory.java</exclude>
-                                        <exclude>com/hazelcast/hibernate/HazelcastTimestamper.java</exclude>
                                         <exclude>com/hazelcast/hibernate/RegionCache.java</exclude>
                                         <exclude>com/hazelcast/hibernate/distributed/IMapRegionCache.java</exclude>
                                         <exclude>com/hazelcast/hibernate/local/LocalRegionCache.java</exclude>

--- a/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultSlowTest.java
+++ b/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultSlowTest.java
@@ -16,15 +16,12 @@
 
 package com.hazelcast.hibernate;
 
-import com.hazelcast.config.MapConfig;
 import com.hazelcast.hibernate.entity.DummyEntity;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.SlowTest;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
-import org.hibernate.cache.spi.support.QueryResultsRegionTemplate;
 import org.hibernate.cfg.Environment;
-import org.hibernate.internal.SessionFactoryImpl;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -41,27 +38,6 @@ public class RegionFactoryDefaultSlowTest extends HibernateSlowTestSupport {
         Properties props = new Properties();
         props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
         return props;
-    }
-
-    @Test
-    public void testQueryCacheCleanup() {
-        MapConfig mapConfig = getHazelcastInstance(sf).getConfig().getMapConfig("default-query-results-region");
-        final float baseEvictionRate = 0.2f;
-        final int numberOfEntities = 100;
-        final int defaultCleanupPeriod = 60;
-        final int maxSize = mapConfig.getMaxSizeConfig().getSize();
-        final int evictedItemCount = numberOfEntities - maxSize + (int) (maxSize * baseEvictionRate);
-        insertDummyEntities(numberOfEntities);
-        for (int i = 0; i < numberOfEntities; i++) {
-            executeQuery(sf, i);
-        }
-
-        QueryResultsRegionTemplate regionTemplate = (QueryResultsRegionTemplate) (((SessionFactoryImpl) sf).getCache()).getDefaultQueryResultsCache().getRegion();
-        RegionCache cache = ((HazelcastStorageAccessImpl) regionTemplate.getStorageAccess()).getDelegate();
-        assertEquals(numberOfEntities, cache.getElementCountInMemory());
-        sleep(defaultCleanupPeriod);
-
-        assertEquals(numberOfEntities - evictedItemCount, cache.getElementCountInMemory());
     }
 
     @SuppressWarnings("Duplicates")

--- a/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/RegionFactoryQueryCacheEvictionSlowTest.java
+++ b/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/RegionFactoryQueryCacheEvictionSlowTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.hibernate.local.TestLocalCacheRegionFactory;
+import com.hazelcast.hibernate.region.TestCacheRegionFactory;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.SlowTest;
+import org.hibernate.cache.spi.support.QueryResultsRegionTemplate;
+import org.hibernate.cfg.Environment;
+import org.hibernate.internal.SessionFactoryImpl;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Properties;
+
+import static com.hazelcast.hibernate.local.TestLocalCacheRegionFactory.CLEANUP_PERIOD;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category(SlowTest.class)
+public class RegionFactoryQueryCacheEvictionSlowTest extends HibernateSlowTestSupport {
+
+    @Parameterized.Parameter
+    public String configFile;
+
+    @Parameterized.Parameter(1)
+    public String regionFactory;
+
+    @Parameterized.Parameters(name = "Executing: {0}, {1}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(
+                /*
+                 * This test is configured such that 60 entities should be evicted from the cache:
+                 *   - number of entities (100) > cache max size (50).
+                 * It is run for both types of cache region factory.
+                 */
+                new Object[]{"hazelcast-custom.xml", TestCacheRegionFactory.class.getName()},
+                new Object[]{"hazelcast-custom.xml", TestLocalCacheRegionFactory.class.getName()},
+
+                /*
+                 * This test is configured such that 0 entities should be evicted from the cache:
+                 *   - number of entities (100) < cache max size (150)
+                 *   - ttl (30) > cleanup period (21)
+                 * It is run for both types of cache region factory.
+                 */
+                new Object[]{"hazelcast-custom-region-factory-slow-test.xml", TestCacheRegionFactory.class.getName()},
+                new Object[]{"hazelcast-custom-region-factory-slow-test.xml", TestLocalCacheRegionFactory.class.getName()}
+        );
+    }
+
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+
+        // Use a specific hazelcast xml config file for these tests
+        props.setProperty(CacheEnvironment.CONFIG_FILE_PATH_LEGACY, configFile);
+
+        // The test regionFactory uses a CleanupService with a shorter delay
+        props.setProperty(Environment.CACHE_REGION_FACTORY, regionFactory);
+
+        return props;
+    }
+
+    @Test
+    public void testQueryCacheCleanup() {
+        MapConfig mapConfig = getHazelcastInstance(sf).getConfig().getMapConfig("default-query-results-region");
+        final float baseEvictionRate = 0.2f;
+        final int numberOfEntities = 100;
+        final int defaultCleanupPeriod = (int) CLEANUP_PERIOD;
+        final int maxSize = mapConfig.getMaxSizeConfig().getSize();
+        final int evictedItemCount = Math.max(0, numberOfEntities - maxSize + (int) (maxSize * baseEvictionRate));
+        insertDummyEntities(numberOfEntities);
+        for (int i = 0; i < numberOfEntities; i++) {
+            executeQuery(sf, i);
+        }
+
+        QueryResultsRegionTemplate regionTemplate = (QueryResultsRegionTemplate) (((SessionFactoryImpl) sf).getCache()).getDefaultQueryResultsCache().getRegion();
+        RegionCache cache = ((HazelcastStorageAccessImpl) regionTemplate.getStorageAccess()).getDelegate();
+        assertEquals(numberOfEntities, cache.getElementCountInMemory());
+        sleep(defaultCleanupPeriod + 1);
+
+        assertEquals("Number of evictions", evictedItemCount, numberOfEntities - cache.getElementCountInMemory());
+    }
+}

--- a/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/RegionFactoryQueryCacheEvictionSlowTest.java
+++ b/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/RegionFactoryQueryCacheEvictionSlowTest.java
@@ -61,7 +61,7 @@ public class RegionFactoryQueryCacheEvictionSlowTest extends HibernateSlowTestSu
                 /*
                  * This test is configured such that 0 entities should be evicted from the cache:
                  *   - number of entities (100) < cache max size (150)
-                 *   - ttl (30) > cleanup period (21)
+                 *   - ttl (30) > cleanup period (6)
                  * It is run for both types of cache region factory.
                  */
                 new Object[]{"hazelcast-custom-region-factory-slow-test.xml", TestCacheRegionFactory.class.getName()},

--- a/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/local/TestLocalCacheRegionFactory.java
+++ b/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/local/TestLocalCacheRegionFactory.java
@@ -12,8 +12,11 @@ import java.util.Map;
  */
 public class TestLocalCacheRegionFactory extends HazelcastLocalCacheRegionFactory {
 
-    // Visible for testing
-    public final static long CLEANUP_PERIOD = 12L;
+    /**
+     * Cleanup period in seconds.
+     * Visible for testing.
+     */
+    public final static long CLEANUP_PERIOD = 6L;
 
     public TestLocalCacheRegionFactory() {
         super();

--- a/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/local/TestLocalCacheRegionFactory.java
+++ b/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/local/TestLocalCacheRegionFactory.java
@@ -1,0 +1,35 @@
+package com.hazelcast.hibernate.local;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.HazelcastLocalCacheRegionFactory;
+import org.hibernate.boot.spi.SessionFactoryOptions;
+import org.hibernate.cache.spi.CacheKeysFactory;
+
+import java.util.Map;
+
+/**
+ * This class just extends HazelcastLocalCacheRegionFactory to allow using a CleanupService with a shorter delay.
+ */
+public class TestLocalCacheRegionFactory extends HazelcastLocalCacheRegionFactory {
+
+    // Visible for testing
+    public final static long CLEANUP_PERIOD = 12L;
+
+    public TestLocalCacheRegionFactory() {
+        super();
+    }
+
+    public TestLocalCacheRegionFactory(final CacheKeysFactory cacheKeysFactory) {
+        super(cacheKeysFactory);
+    }
+
+    public TestLocalCacheRegionFactory(final HazelcastInstance instance) {
+        super(instance);
+    }
+
+    @Override
+    protected void prepareForUse(final SessionFactoryOptions settings, final Map configValues) {
+        super.prepareForUse(settings, configValues);
+        cleanupService = new CleanupService("TestLocalCacheRegionFactory", CLEANUP_PERIOD);
+    }
+}

--- a/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/region/TestCacheRegionFactory.java
+++ b/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/region/TestCacheRegionFactory.java
@@ -1,0 +1,36 @@
+package com.hazelcast.hibernate.region;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.HazelcastCacheRegionFactory;
+import com.hazelcast.hibernate.local.CleanupService;
+import org.hibernate.boot.spi.SessionFactoryOptions;
+import org.hibernate.cache.spi.CacheKeysFactory;
+
+import java.util.Map;
+
+/**
+ * This class just extends HazelcastCacheRegionFactory to allow using a CleanupService with a shorter delay.
+ */
+public class TestCacheRegionFactory extends HazelcastCacheRegionFactory {
+
+    // Visible for testing
+    public final static long CLEANUP_PERIOD = 12L;
+
+    public TestCacheRegionFactory() {
+        super();
+    }
+
+    public TestCacheRegionFactory(final CacheKeysFactory cacheKeysFactory) {
+        super(cacheKeysFactory);
+    }
+
+    public TestCacheRegionFactory(final HazelcastInstance instance) {
+        super(instance);
+    }
+
+    @Override
+    protected void prepareForUse(final SessionFactoryOptions settings, final Map configValues) {
+        super.prepareForUse(settings, configValues);
+        cleanupService = new CleanupService("TestCacheRegionFactory", CLEANUP_PERIOD);
+    }
+}

--- a/hazelcast-hibernate53/src/test/resources/hazelcast-custom-region-factory-slow-test.xml
+++ b/hazelcast-hibernate53/src/test/resources/hazelcast-custom-region-factory-slow-test.xml
@@ -19,21 +19,8 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
            http://www.hazelcast.com/schema/config/hazelcast-config-3.4.xsd">
-    <group>
-        <name>dev-custom</name>
-        <password>dev-pass</password>
-    </group>
     <network>
         <port auto-increment="true">5701</port>
-        <join>
-            <multicast enabled="false">
-                <multicast-group>224.2.2.3</multicast-group>
-                <multicast-port>54327</multicast-port>
-            </multicast>
-            <tcp-ip enabled="true">
-                <interface>127.0.0.1</interface>
-            </tcp-ip>
-        </join>
         <interfaces enabled="false">
             <interface>10.3.17.*</interface>
         </interfaces>

--- a/hazelcast-hibernate53/src/test/resources/hazelcast-custom-region-factory-slow-test.xml
+++ b/hazelcast-hibernate53/src/test/resources/hazelcast-custom-region-factory-slow-test.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-3.4.xsd">
+    <group>
+        <name>dev-custom</name>
+        <password>dev-pass</password>
+    </group>
+    <network>
+        <port auto-increment="true">5701</port>
+        <join>
+            <multicast enabled="false">
+                <multicast-group>224.2.2.3</multicast-group>
+                <multicast-port>54327</multicast-port>
+            </multicast>
+            <tcp-ip enabled="true">
+                <interface>127.0.0.1</interface>
+            </tcp-ip>
+        </join>
+        <interfaces enabled="false">
+            <interface>10.3.17.*</interface>
+        </interfaces>
+    </network>
+    <map name="default">
+        <!--
+            Number of backups. If 1 is set as the backup-count for example,
+            then all entries of the map will be copied to another JVM for
+            fail-safety. Valid numbers are 0 (no backup), 1, 2, 3.
+        -->
+        <backup-count>1</backup-count>
+        <!--
+            Valid values are:
+            NONE (no eviction),
+            LRU (Least Recently Used),
+            LFU (Least Frequiently Used).
+            NONE is the default.
+        -->
+        <eviction-policy>NONE</eviction-policy>
+        <!--
+            Maximum size of the map. When max size is reached,
+            map is evicted based on the policy defined.
+            Any integer between 0 and Integer.MAX_VALUE. 0 means
+            Integer.MAX_VALUE. Default is 0.
+        -->
+        <max-size>0</max-size>
+        <!--
+            When max. size is reached, specified percentage of
+            the map will be evicted. Any integer between 0 and 100.
+            If 25 is set for example, 25% of the entries will
+            get evicted.
+        -->
+        <eviction-percentage>25</eviction-percentage>
+    </map>
+
+    <!-- Config for query cache -->
+    <map name="default-query-results-region">
+        <time-to-live-seconds>30</time-to-live-seconds>
+        <max-size>150</max-size>
+    </map>
+</hazelcast>


### PR DESCRIPTION
* reverted LocalRegionCache to use ``HazelcastTimestamper.nextTimestamp``
  (as Hibernate's ``SimpleTimestamper`` is not returning values in milliseconds, which is required for the expiry calculation)
* added test cases for this scenario to ``RegionFactoryQueryCacheEvictionSlowTest``
* changed ``CleanupService`` to allow the ``fixedDelay`` to be configurable, for use in the above tests