### PR TITLE
Change MapMergePolicy to SplitBrainMergePolicy.

### DIFF
--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/VersionAwareMapMergePolicy.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/VersionAwareMapMergePolicy.java
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.hazelcast.hibernate;
+
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.merge.MergingValue;
@@ -24,7 +26,7 @@ import java.io.IOException;
  * A merge policy implementation to handle split brain remerges based on the timestamps stored in
  * the values.
  */
-public class VersionAwareMapMergePolicy implements SplitBrainMergePolicy<Object,MergingValue<Object>> {
+public class VersionAwareMapMergePolicy implements SplitBrainMergePolicy<Object, MergingValue<Object>> {
 
 
     public Object merge(MergingValue<Object> mergingValue, MergingValue<Object> existingValue) {
@@ -32,7 +34,9 @@ public class VersionAwareMapMergePolicy implements SplitBrainMergePolicy<Object,
         final Object mergingVal = mergingValue.getValue();
         final Object existingVal = existingValue.getValue();
 
-        if(existingVal == null) { return mergingVal; }
+        if (existingVal == null) {
+            return mergingVal;
+        }
 
         if (existingVal != null && existingVal instanceof CacheEntry
                 && mergingVal != null && mergingVal instanceof CacheEntry) {

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/VersionAwareMapMergePolicy.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/VersionAwareMapMergePolicy.java
@@ -33,7 +33,7 @@ public class VersionAwareMapMergePolicy implements SplitBrainMergePolicy<Object,
     @Override
     public Object merge(MergingValue<Object> mergingVal, MergingValue<Object> existingVal) {
         final Object existingValue = existingVal != null ? existingVal.getValue() : null;
-        final Object mergingValue = mergingVal.getValue();
+        final Object mergingValue = mergingVal != null ? mergingVal.getValue() : null;
         if (existingValue instanceof CacheEntry && mergingValue instanceof CacheEntry) {
 
             final CacheEntry existingCacheEntry = (CacheEntry) existingValue;
@@ -56,10 +56,10 @@ public class VersionAwareMapMergePolicy implements SplitBrainMergePolicy<Object,
     }
 
     @Override
-    public void writeData(final ObjectDataOutput out) throws IOException {
+    public void writeData(ObjectDataOutput out) throws IOException {
     }
 
     @Override
-    public void readData(final ObjectDataInput in) throws IOException {
+    public void readData(ObjectDataInput in) throws IOException {
     }
 }

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/VersionAwareMapMergePolicy.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/VersionAwareMapMergePolicy.java
@@ -38,14 +38,13 @@ public class VersionAwareMapMergePolicy implements SplitBrainMergePolicy<Object,
             return mergingVal;
         }
 
-        if (existingVal != null && existingVal instanceof CacheEntry
-                && mergingVal != null && mergingVal instanceof CacheEntry) {
+        if (existingVal instanceof CacheEntry
+                && mergingVal instanceof CacheEntry) {
             CacheEntry existingCacheEntry = (CacheEntry) existingVal;
             CacheEntry mergingCacheEntry = (CacheEntry) mergingVal;
             final Object mergingVersionObject = mergingCacheEntry.getVersion();
             final Object existingVersionObject = existingCacheEntry.getVersion();
-            if (mergingVersionObject != null && existingVersionObject != null
-                    && mergingVersionObject instanceof Comparable && existingVersionObject instanceof Comparable) {
+            if (mergingVersionObject instanceof Comparable && existingVersionObject instanceof Comparable) {
                 final Comparable mergingVersion = (Comparable) mergingVersionObject;
                 final Comparable existingVersion = (Comparable) existingVersionObject;
                 if (mergingVersion.compareTo(existingVersion) > 0) {

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/VersionAwareMapMergePolicyTest.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/VersionAwareMapMergePolicyTest.java
@@ -1,7 +1,8 @@
 package com.hazelcast.hibernate;
 
-import com.hazelcast.core.EntryView;
-import com.hazelcast.map.merge.MapMergePolicy;
+
+import com.hazelcast.spi.merge.MergingValue;
+import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -23,7 +24,7 @@ public class VersionAwareMapMergePolicyTest {
     private static final MockVersion versionOld = new MockVersion(0);
     private static final MockVersion versionNew = new MockVersion(1);
 
-    protected MapMergePolicy policy;
+    protected SplitBrainMergePolicy policy;
 
     @Before
     public void given() {
@@ -35,10 +36,10 @@ public class VersionAwareMapMergePolicyTest {
         CacheEntry existing = cacheEntryWithVersion(versionOld);
         CacheEntry merging = cacheEntryWithVersion(versionNew);
 
-        EntryView entryExisting = entryWithGivenValue(existing);
-        EntryView entryMerging = entryWithGivenValue(merging);
+        MergingValue entryExisting = entryWithGivenValue(existing);
+        MergingValue entryMerging = entryWithGivenValue(merging);
 
-        assertEquals(merging, policy.merge("map", entryMerging, entryExisting));
+        assertEquals(merging, policy.merge(entryMerging, entryExisting));
     }
 
     @Test
@@ -46,10 +47,10 @@ public class VersionAwareMapMergePolicyTest {
         CacheEntry existing = cacheEntryWithVersion(versionNew);
         CacheEntry merging = cacheEntryWithVersion(versionOld);
 
-        EntryView entryExisting = entryWithGivenValue(existing);
-        EntryView entryMerging = entryWithGivenValue(merging);
+        MergingValue entryExisting = entryWithGivenValue(existing);
+        MergingValue entryMerging = entryWithGivenValue(merging);
 
-        assertEquals(existing, policy.merge("map", entryMerging, entryExisting));
+        assertEquals(existing, policy.merge(entryMerging, entryExisting));
     }
 
     @Test
@@ -57,10 +58,10 @@ public class VersionAwareMapMergePolicyTest {
         CacheEntry existing = null;
         CacheEntry merging = cacheEntryWithVersion(versionNew);
 
-        EntryView entryExisting = entryWithGivenValue(existing);
-        EntryView entryMerging = entryWithGivenValue(merging);
+        MergingValue entryExisting = entryWithGivenValue(existing);
+        MergingValue entryMerging = entryWithGivenValue(merging);
 
-        assertEquals(merging, policy.merge("map", entryMerging, entryExisting));
+        assertEquals(merging, policy.merge(entryMerging, entryExisting));
     }
 
 
@@ -70,11 +71,11 @@ public class VersionAwareMapMergePolicyTest {
         return cacheEntry;
     }
 
-    private EntryView entryWithGivenValue(Object value) {
-        EntryView entryView = mock(EntryView.class);
+    private MergingValue entryWithGivenValue(Object value) {
+        MergingValue mergingValue= mock(MergingValue.class);
         try {
-            when(entryView.getValue()).thenReturn(value);
-            return entryView;
+            when(mergingValue.getValue()).thenReturn(value);
+            return mergingValue;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/serialization/HibernateSerializationHookAvailableTest.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/serialization/HibernateSerializationHookAvailableTest.java
@@ -21,7 +21,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.impl.HazelcastInstanceImpl;
 import com.hazelcast.instance.impl.HazelcastInstanceProxy;
 import com.hazelcast.internal.serialization.impl.AbstractSerializationService;
-import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.hibernate.cache.spi.entry.StandardCacheEntryImpl;


### PR DESCRIPTION
MapMergePolicy is deprecated in Hazelcast 4.0. Instead, SplitBrainMergePolicy is used.