### PR TITLE
Parallelize CI jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
         java: [ '8' ]
         architecture: [ 'x64' ]
         module: ['hazelcast-hibernate5', 'hazelcast-hibernate52', 'hazelcast-hibernate53']
-    name: Build with JDK ${{ matrix.java }} on ${{ matrix.architecture }}
+    name: Build ${{ matrix.module }} with JDK ${{ matrix.java }} on ${{ matrix.architecture }}
     steps:
       - uses: actions/checkout@v1
       - name: Setup JDK

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,5 +28,5 @@ jobs:
           restore-keys: ${{ runner.os }}-maven-
 
       - name: Build with Maven
-        run:  mvn -f ${{module}}/pom.xml verify
+        run: mvn -f ${{ matrix.module }}/pom.xml verify
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         java: [ '8' ]
         architecture: [ 'x64' ]
+        module: ['hazelcast-hibernate5', 'hazelcast-hibernate52', 'hazelcast-hibernate53']
     name: Build with JDK ${{ matrix.java }} on ${{ matrix.architecture }}
     steps:
       - uses: actions/checkout@v1
@@ -27,5 +28,5 @@ jobs:
           restore-keys: ${{ runner.os }}-maven-
 
       - name: Build with Maven
-        run: mvn package
+        run:  mvn -f ${{module}}/pom.xml verify
 


### PR DESCRIPTION
Since modules are independent, let's build them in parallel to save time.