### PR TITLE
Decouple hazelcast-hibernate52 tests from hazelcast-hibernate5

### DIFF
--- a/hazelcast-hibernate52/pom.xml
+++ b/hazelcast-hibernate52/pom.xml
@@ -34,14 +34,6 @@
     </properties>
 
     <build>
-        <!-- Reuse tests from hibernate5 module -->
-        <testSourceDirectory>../hazelcast-hibernate5/src/test/java</testSourceDirectory>
-        <testResources>
-            <testResource>
-                <directory>../hazelcast-hibernate5/src/test/resources</directory>
-            </testResource>
-        </testResources>
-
         <!-- Overlay code onto hibernate5 module -->
         <plugins>
             <plugin>

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/CacheHitMissNonStrictTest.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/CacheHitMissNonStrictTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cfg.Environment;
+import org.hibernate.stat.SecondLevelCacheStatistics;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Read and write access (non-strict) cache concurrency strategy of Hibernate.
+ * Data may be added, removed and mutated.
+ * Nonstrict means that data integrity is not preserved as strictly as in READ_WRITE access
+ * Cache invalidations are asychrnonous
+ * Read through cache
+ */
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class CacheHitMissNonStrictTest extends HibernateStatisticsTestSupport {
+
+    @Override
+    protected AccessType getCacheStrategy() {
+        return AccessType.NONSTRICT_READ_WRITE;
+    }
+
+    @Override
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        return props;
+    }
+
+    @Test
+    public void testGetUpdateRemoveGet()
+            throws Exception {
+        insertDummyEntities(10, 4);
+        //all 10 entities and 40 properties are cached
+        SecondLevelCacheStatistics dummyEntityCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_ENTITY);
+        SecondLevelCacheStatistics dummyPropertyCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_PROPERTY);
+
+        sf.getCache().evictEntityRegions();
+        sf.getCache().evictCollectionRegions();
+
+        //miss 10 entities
+        getDummyEntities(10);
+
+        //hit 1 entity and 4 properties
+        updateDummyEntityName(2, "updated");
+
+        //entity 2 and its properties are invalidated
+
+        //miss updated entity, hit 4 properties(they are still the same)
+        getPropertiesOfEntity(2);
+
+        //hit 1 entity and 4 properties
+        deleteDummyEntity(1);
+
+        assertEquals(12, dummyPropertyCacheStats.getHitCount());
+        assertEquals(0, dummyPropertyCacheStats.getMissCount());
+        assertEquals(2, dummyEntityCacheStats.getHitCount());
+        assertEquals(11, dummyEntityCacheStats.getMissCount());
+    }
+
+    @Test
+    public void testUpdateEventuallyInvalidatesObject() {
+        insertDummyEntities(10, 4);
+        //all 10 entities and 40 properties are cached
+        SecondLevelCacheStatistics dummyEntityCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_ENTITY);
+        SecondLevelCacheStatistics dummyPropertyCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_PROPERTY);
+
+        sf.getCache().evictEntityRegions();
+        sf.getCache().evictCollectionRegions();
+
+        //miss 10 entities
+        getDummyEntities(10);
+
+        //hit 1 entity and 4 properties
+        updateDummyEntityName(2, "updated");
+        assertSizeEventually(9, dummyEntityCacheStats.getEntries());
+    }
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/CacheHitMissReadOnlyTest.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/CacheHitMissReadOnlyTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.hibernate.access.ReadOnlyAccessDelegate;
+import com.hazelcast.hibernate.region.HazelcastRegion;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cfg.Environment;
+import org.hibernate.stat.SecondLevelCacheStatistics;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Read-only access cache concurrency strategy of Hibernate.
+ * Data may be added and removed, but not mutated.
+ */
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class CacheHitMissReadOnlyTest extends HibernateStatisticsTestSupport {
+
+    @Override
+    protected AccessType getCacheStrategy() {
+        return AccessType.READ_ONLY;
+    }
+
+    @Override
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        return props;
+    }
+
+    @Test
+    public void testGetUpdateRemoveGet() throws Exception {
+        insertDummyEntities(10, 4);
+        //all 10 entities and 40 properties are cached
+        SecondLevelCacheStatistics dummyEntityCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_ENTITY);
+        SecondLevelCacheStatistics dummyPropertyCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_PROPERTY);
+
+        sf.getCache().evictEntityRegions();
+        sf.getCache().evictCollectionRegions();
+        //miss 10 entities
+        getDummyEntities(10);
+        //hit 1 entity and 4 properties
+        deleteDummyEntity(1);
+
+        assertEquals(4, dummyPropertyCacheStats.getHitCount());
+        assertEquals(0, dummyPropertyCacheStats.getMissCount());
+        assertEquals(1, dummyEntityCacheStats.getHitCount());
+        assertEquals(10, dummyEntityCacheStats.getMissCount());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testUpdateQueryCausesInvalidationOfEntireRegion() {
+        insertDummyEntities(10);
+        executeUpdateQuery("UPDATE DummyEntity set name = 'manually-updated' where id=2");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testReadOnlyUpdate() {
+        insertDummyEntities(1, 0);
+        updateDummyEntityName(0, "updated");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testAfterUpdateShouldThrowOnReadOnly() {
+        HazelcastRegion hzRegion = mock(HazelcastRegion.class);
+        when(hzRegion.getCache()).thenReturn(null);
+        when(hzRegion.getLogger()).thenReturn(null);
+        ReadOnlyAccessDelegate readOnlyAccessDelegate = new ReadOnlyAccessDelegate(hzRegion, null);
+        readOnlyAccessDelegate.afterUpdate(null, null, null, null, null);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testUpdateQueryCausesInvalidationOfEntireCollectionRegion() {
+        insertDummyEntities(1, 10);
+
+        //attempt to evict properties reference in DummyEntity because of custom SQL query on Collection region
+        executeUpdateQuery("update DummyProperty ent set ent.key='manually-updated'");
+    }
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/CacheHitMissReadWriteTest.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/CacheHitMissReadWriteTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cfg.Environment;
+import org.hibernate.stat.SecondLevelCacheStatistics;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Read and write access (strict) cache concurrency strategy of Hibernate.
+ * Data may be added, removed and mutated.
+ * Strict means data integrity is preserved strictly (by locks)
+ * Write through cache
+ */
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class CacheHitMissReadWriteTest extends HibernateStatisticsTestSupport {
+
+    @Override
+    protected AccessType getCacheStrategy() {
+        return AccessType.READ_WRITE;
+    }
+
+    @Override
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        return props;
+    }
+
+    @Test
+    public void testGetUpdateRemoveGet()
+            throws Exception {
+        insertDummyEntities(10, 4);
+        //all 10 entities and 40 properties are cached
+        SecondLevelCacheStatistics dummyEntityCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_ENTITY);
+        SecondLevelCacheStatistics dummyPropertyCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_PROPERTY);
+
+        sf.getCache().evictEntityRegions();
+        sf.getCache().evictCollectionRegions();
+
+        //miss 10 entities
+        getDummyEntities(10);
+
+        //hit 1 entity and 4 properties
+        updateDummyEntityName(2, "updated");
+
+        //hit 1 entity, hit 4 properties
+        getPropertiesOfEntity(2);
+        //hit 1 entity and 4 properties
+        deleteDummyEntity(1);
+
+        assertEquals(12, dummyPropertyCacheStats.getHitCount());
+        assertEquals(0, dummyPropertyCacheStats.getMissCount());
+        assertEquals(3, dummyEntityCacheStats.getHitCount());
+        assertEquals(10, dummyEntityCacheStats.getMissCount());
+
+    }
+
+    @Test
+    public void testUpdateShouldNotInvalidateEntryInCache() {
+        insertDummyEntities(10, 4);
+        //all 10 entities and 40 properties are cached
+        SecondLevelCacheStatistics dummyEntityCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_ENTITY);
+
+        sf.getCache().evictEntityRegions();
+        sf.getCache().evictCollectionRegions();
+
+        //miss 10 entities, 10 entities are cached
+        getDummyEntities(10);
+
+        //updates cache entity
+        updateDummyEntityName(2, "updated");
+
+        assertEquals(10, dummyEntityCacheStats.getElementCountInMemory());
+    }
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/CollectionCacheTest.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/CollectionCacheTest.java
@@ -1,0 +1,115 @@
+package com.hazelcast.hibernate;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.hibernate.entity.DummyProperty;
+import com.hazelcast.hibernate.instance.HazelcastMockInstanceLoader;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.SlowTest;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.Environment;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category(SlowTest.class)
+public class CollectionCacheTest extends HibernateTestSupport {
+
+    @Parameterized.Parameter(0)
+    public String cacheRegionFactory;
+
+    private TestHazelcastFactory factory;
+    private SessionFactory sf;
+
+    @Parameterized.Parameters(name = "Executing: {0}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[]{HazelcastLocalCacheRegionFactory.class.getName()},
+                new Object[]{HazelcastCacheRegionFactory.class.getName()}
+        );
+    }
+
+    @Before
+    public void postConstruct() {
+        HazelcastMockInstanceLoader loader = new HazelcastMockInstanceLoader();
+        factory = new TestHazelcastFactory();
+        loader.setInstanceFactory(factory);
+        sf = createSessionFactory(getCacheProperties(),  loader);
+    }
+
+    @After
+    public void preDestroy() {
+        if (sf != null) {
+            sf.close();
+            sf = null;
+        }
+        Hazelcast.shutdownAll();
+        factory.shutdownAll();
+    }
+
+    @Test
+    public void testReplaceCollection() throws Exception {
+        Session session = sf.openSession();
+        Transaction transaction = session.beginTransaction();
+
+        DummyProperty someProp = new DummyProperty("some prop");
+        session.save(someProp);
+
+        DummyEntity entity = new DummyEntity();
+        entity.setId(1L);
+        entity.setName("some entity");
+        entity.setValue(27.0);
+        entity.setDate(new Date(System.currentTimeMillis()));
+        entity.setProperties(new HashSet<DummyProperty>(Collections.singletonList(someProp)));
+        session.save(entity);
+
+        transaction.commit();
+        session.close();
+
+        session = sf.openSession();
+        transaction = session.beginTransaction();
+
+        DummyProperty property = new DummyProperty("somekey");
+        session.save(property);
+
+        entity = (DummyEntity) session.get(DummyEntity.class, 1L);
+        HashSet<DummyProperty> updatedProperties = new HashSet<DummyProperty>();
+        updatedProperties.add(property);
+        entity.setProperties(updatedProperties);
+
+        session.update(entity);
+
+        transaction.commit();
+        session.close();
+
+        session = sf.openSession();
+
+        entity = (DummyEntity) session.load(DummyEntity.class, entity.getId());
+        // just for making Hibernate load the object
+        assertEquals("some entity", entity.getName());
+
+        session.close();
+    }
+
+    private Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, cacheRegionFactory);
+        return props;
+    }
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/CustomPropertiesTest.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/CustomPropertiesTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.clientside.HazelcastClientProxy;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.ClasspathXmlConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.hibernate.instance.HazelcastAccessor;
+import com.hazelcast.hibernate.instance.HazelcastMockInstanceLoader;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.SlowTest;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
+import org.hibernate.service.spi.ServiceException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.util.Date;
+import java.util.Properties;
+
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.isA;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
+public class CustomPropertiesTest extends HibernateTestSupport {
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void testNativeClient() throws Exception {
+        TestHazelcastFactory factory = new TestHazelcastFactory();
+        Config config = new ClasspathXmlConfig("hazelcast-custom.xml");
+        HazelcastInstance main = factory.newHazelcastInstance(config);
+        Properties props = getDefaultProperties();
+        props.remove(CacheEnvironment.CONFIG_FILE_PATH_LEGACY);
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        props.setProperty(CacheEnvironment.USE_NATIVE_CLIENT, "true");
+        props.setProperty(CacheEnvironment.NATIVE_CLIENT_CLUSTER_NAME, "dev-custom");
+        props.setProperty(CacheEnvironment.CONFIG_FILE_PATH,"hazelcast-client-custom.xml");
+        HazelcastMockInstanceLoader loader = new HazelcastMockInstanceLoader();
+        loader.configure(props);
+        loader.setInstanceFactory(factory);
+        SessionFactory sf = createSessionFactory(props, loader);
+        final HazelcastInstance hz = HazelcastAccessor.getHazelcastInstance(sf);
+        assertTrue(hz instanceof HazelcastClientProxy);
+        assertEquals(1, main.getCluster().getMembers().size());
+        HazelcastClientProxy client = (HazelcastClientProxy) hz;
+        ClientConfig clientConfig = client.getClientConfig();
+        assertEquals("dev-custom", clientConfig.getClusterName());
+        assertTrue(clientConfig.getNetworkConfig().isSmartRouting());
+        assertTrue(clientConfig.getNetworkConfig().isRedoOperation());
+        factory.newHazelcastInstance(config);
+        assertEquals(2, hz.getCluster().getMembers().size());
+        main.shutdown();
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(1, hz.getCluster().getMembers().size());
+            }
+        });
+
+        assertEquals(1, hz.getCluster().getMembers().size());
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        session.save(new DummyEntity(1L, "dummy", 0, new Date()));
+        tx.commit();
+        session.close();
+        sf.close();
+        factory.shutdownAll();
+    }
+
+    @Test
+    public void testNamedInstance() {
+        TestHazelcastFactory factory = new TestHazelcastFactory();
+        Config config = new Config();
+        config.setInstanceName("hibernate");
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        props.put(CacheEnvironment.HAZELCAST_INSTANCE_NAME, "hibernate");
+        props.put(CacheEnvironment.SHUTDOWN_ON_STOP, "false");
+        props.setProperty("hibernate.dialect", "org.hibernate.dialect.HSQLDialect");
+
+        Configuration configuration = new Configuration();
+        configuration.addProperties(props);
+
+        SessionFactory sf = configuration.buildSessionFactory();
+        assertTrue(hz.equals(HazelcastAccessor.getHazelcastInstance(sf)));
+        sf.close();
+        assertTrue(hz.getLifecycleService().isRunning());
+        factory.shutdownAll();
+    }
+
+    @Test
+    public void testNamedInstance_noInstance() {
+        exception.expect(ServiceException.class);
+        exception.expectCause(allOf(isA(CacheException.class), new BaseMatcher<CacheException>() {
+            @Override
+            public boolean matches(Object item) {
+                return ((CacheException) item).getMessage().contains("No instance with name [hibernate] could be found.");
+            }
+
+            @Override
+            public void describeTo(Description description) {
+            }
+        }));
+
+        Config config = new Config();
+        config.setInstanceName("hibernate");
+
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        props.put(CacheEnvironment.HAZELCAST_INSTANCE_NAME, "hibernate");
+        props.put(CacheEnvironment.SHUTDOWN_ON_STOP, "false");
+        props.setProperty("hibernate.dialect", "org.hibernate.dialect.HSQLDialect");
+
+        Configuration configuration = new Configuration();
+        configuration.addProperties(props);
+
+        SessionFactory sf = configuration.buildSessionFactory();
+        sf.close();
+    }
+
+    @Test
+    public void testNamedClient_noInstance() throws Exception {
+        exception.expect(ServiceException.class);
+        exception.expectCause(allOf(isA(CacheException.class), new BaseMatcher<CacheException>() {
+            @Override
+            public boolean matches(Object item) {
+                return ((CacheException) item).getMessage().contains("No client with name [dev-custom] could be found.");
+            }
+
+            @Override
+            public void describeTo(Description description) {
+            }
+        }));
+
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        props.setProperty(CacheEnvironment.USE_NATIVE_CLIENT, "true");
+        props.setProperty(CacheEnvironment.NATIVE_CLIENT_INSTANCE_NAME, "dev-custom");
+        props.setProperty("hibernate.dialect", "org.hibernate.dialect.HSQLDialect");
+
+        Configuration configuration = new Configuration();
+        configuration.addProperties(props);
+
+        SessionFactory sf = configuration.buildSessionFactory();
+        sf.close();
+    }
+
+    @Test
+    public void testHazelcastAccessorReturnsNullIfSecondLevelCacheIsNotHazelcast() {
+        Properties props = new Properties();
+        props.setProperty("hibernate.dialect", "org.hibernate.dialect.HSQLDialect");
+
+        Configuration configuration = new Configuration();
+        configuration.addProperties(props);
+        SessionFactory sf = configuration.buildSessionFactory();
+
+        assertNull(HazelcastAccessor.getHazelcastInstance(sf));
+
+        sf.close();
+    }
+
+    @Test(expected = ServiceException.class)
+    public void testWrongHazelcastConfigurationFilePathShouldThrow() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        props.setProperty("hibernate.dialect", "org.hibernate.dialect.HSQLDialect");
+
+        //we give a non-exist config file address, should fail fast
+        props.setProperty("hibernate.cache.hazelcast.configuration_file_path", "non-exist.xml");
+
+        Configuration configuration = new Configuration();
+        configuration.addProperties(props);
+        SessionFactory sf = configuration.buildSessionFactory();
+        sf.close();
+    }
+
+    private Properties getDefaultProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        props.setProperty(CacheEnvironment.CONFIG_FILE_PATH_LEGACY, "hazelcast-custom.xml");
+        return props;
+    }
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/HibernateSlowTestSupport.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/HibernateSlowTestSupport.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.hibernate.entity.DummyProperty;
+import org.hibernate.Query;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Properties;
+
+public abstract class HibernateSlowTestSupport extends HibernateTestSupport {
+
+    protected SessionFactory sf;
+    protected SessionFactory sf2;
+
+    @Before
+    public void postConstruct() {
+        sf = createSessionFactory(getCacheProperties(), null);
+        sf2 = createSessionFactory(getCacheProperties(), null);
+    }
+
+    @After
+    public void preDestroy() {
+        if (sf != null) {
+            sf.close();
+            sf = null;
+        }
+        if (sf2 != null) {
+            sf2.close();
+            sf2 = null;
+        }
+        Hazelcast.shutdownAll();
+    }
+
+    protected abstract Properties getCacheProperties();
+
+    protected void insertDummyEntities(int count) {
+        insertDummyEntities(count, 0);
+    }
+
+    protected void insertDummyEntities(int count, int childCount) {
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        try {
+            for (int i = 0; i < count; i++) {
+                DummyEntity e = new DummyEntity((long) i, "dummy:" + i, i * 123456d, new Date());
+                session.save(e);
+                for (int j = 0; j < childCount; j++) {
+                    DummyProperty p = new DummyProperty("key:" + j, e);
+                    session.save(p);
+                }
+            }
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            e.printStackTrace();
+        } finally {
+            session.close();
+        }
+    }
+
+    protected List<DummyEntity> executeQuery(SessionFactory factory) {
+        Session session = factory.openSession();
+        try {
+            Query query = session.createQuery("from " + DummyEntity.class.getName());
+            query.setCacheable(false);
+            return query.list();
+        } finally {
+            session.close();
+        }
+    }
+
+    protected DummyEntity executeQuery(SessionFactory factory, long id) {
+        Session session = factory.openSession();
+        try {
+            Query query = session.createQuery("from " + DummyEntity.class.getName() + " where id = " + id);
+            query.setCacheable(true);
+            return (DummyEntity) query.list().get(0);
+        } finally {
+            session.close();
+        }
+    }
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/HibernateStatisticsTestSupport.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/HibernateStatisticsTestSupport.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.hibernate.entity.DummyProperty;
+import com.hazelcast.hibernate.instance.HazelcastMockInstanceLoader;
+import org.hibernate.Query;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.SecondLevelCacheStatistics;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+
+public abstract class HibernateStatisticsTestSupport extends HibernateTestSupport {
+
+    private final TestHazelcastFactory factory  = new TestHazelcastFactory();
+
+    protected SessionFactory sf;
+    protected SessionFactory sf2;
+
+    @Before
+    public void postConstruct() {
+        HazelcastMockInstanceLoader loader = new HazelcastMockInstanceLoader();
+        loader.setInstanceFactory(factory);
+        sf = createSessionFactory(getCacheProperties(),  loader);
+        sf2 = createSessionFactory(getCacheProperties(), loader);
+    }
+
+    @After
+    public void preDestroy() {
+        if (sf != null) {
+            sf.close();
+            sf = null;
+        }
+        if (sf2 != null) {
+            sf2.close();
+            sf2 = null;
+        }
+        Hazelcast.shutdownAll();
+        factory.shutdownAll();
+    }
+
+    protected abstract Properties getCacheProperties();
+
+    protected void insertDummyEntities(int count) {
+        insertDummyEntities(sf, count, 0);
+    }
+
+    protected void insertDummyEntities(int count, int childCount) {
+        insertDummyEntities(sf, count, childCount);
+    }
+
+    protected void insertAnnotatedEntities(int count) {
+        insertAnnotatedEntities(sf, count);
+    }
+
+    protected List<DummyEntity> executeQuery() {
+        Session session = sf.openSession();
+        try {
+            Query query = session.createQuery("from " + DummyEntity.class.getName());
+            query.setCacheable(true);
+            return query.list();
+        } finally {
+            session.close();
+        }
+    }
+
+    protected ArrayList<DummyEntity> getDummyEntities(long untilId) {
+        return getDummyEntities(sf, untilId);
+    }
+
+    protected Set<DummyProperty> getPropertiesOfEntity(long entityId) {
+        Session session = sf.openSession();
+        DummyEntity entity = session.get(DummyEntity.class, entityId);
+        if (entity != null) {
+            return entity.getProperties();
+        } else {
+            return null;
+        }
+    }
+
+    protected void updateDummyEntityName(long id, String newName) {
+        updateDummyEntityName(sf, id, newName);
+    }
+
+    protected void deleteDummyEntity(long id) throws Exception {
+        deleteDummyEntity(sf, id);
+    }
+
+    protected void executeUpdateQuery(String queryString) throws RuntimeException {
+        executeUpdateQuery(sf, queryString);
+    }
+
+    @Test
+    public void testUpdateQueryCausesInvalidationOfEntireRegion() {
+        insertDummyEntities(10);
+
+        executeUpdateQuery(sf, "UPDATE DummyEntity set name = 'manually-updated' where id=2");
+
+        sf.getStatistics().clear();
+
+        getDummyEntities(sf, 10);
+
+        SecondLevelCacheStatistics dummyEntityCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_ENTITY);
+        assertEquals(10, dummyEntityCacheStats.getMissCount());
+        assertEquals(0, dummyEntityCacheStats.getHitCount());
+    }
+
+    @Test
+    public void testUpdateQueryCausesInvalidationOfEntireCollectionRegion() {
+        insertDummyEntities(1, 10);
+
+        //properties reference in DummyEntity is evicted because of custom SQL query on Collection region
+        executeUpdateQuery(sf, "update DummyProperty ent set ent.key='manually-updated'");
+        sf.getStatistics().clear();
+
+        //property reference missed in cache.
+        getPropertiesOfEntity(0);
+
+        SecondLevelCacheStatistics dummyPropertyCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_ENTITY + ".properties");
+        assertEquals(0, dummyPropertyCacheStats.getHitCount());
+        assertEquals(1, dummyPropertyCacheStats.getMissCount());
+    }
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/HibernateTestSupport.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/HibernateTestSupport.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.entity.AnnotatedEntity;
+import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.hibernate.entity.DummyProperty;
+import com.hazelcast.hibernate.instance.HazelcastAccessor;
+import com.hazelcast.hibernate.instance.HazelcastMockInstanceFactory;
+import com.hazelcast.hibernate.instance.IHazelcastInstanceLoader;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.internal.nio.IOUtil;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.hibernate.Query;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cfg.Configuration;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Properties;
+
+public abstract class HibernateTestSupport extends HazelcastTestSupport {
+
+    private final ILogger logger = Logger.getLogger(getClass());
+
+    protected final String CACHE_ENTITY = DummyEntity.class.getName();
+    protected final String CACHE_PROPERTY = DummyProperty.class.getName();
+
+    @BeforeClass
+    @AfterClass
+    public static void tearUpAndDown() {
+        Hazelcast.shutdownAll();
+    }
+
+    @After
+    public final void cleanup() {
+        Hazelcast.shutdownAll();
+    }
+
+    protected AccessType getCacheStrategy() {
+        return AccessType.READ_WRITE;
+    }
+
+    protected void sleep(int seconds) {
+        try {
+            Thread.sleep(1000 * seconds);
+        } catch (InterruptedException e) {
+            logger.warning("", e);
+        }
+    }
+
+    protected void addHbmMappings(final Configuration conf) {
+        conf.addFile(createHbmXml("DummyEntity"));
+        conf.addFile(createHbmXml("DummyProperty"));
+    }
+
+    protected void addMappings(final Configuration conf) {
+        conf.addAnnotatedClass(AnnotatedEntity.class);
+        addHbmMappings(conf);
+    }
+
+    protected SessionFactory createSessionFactory(final Properties props,
+                                                  final IHazelcastInstanceLoader customInstanceLoader) {
+        props.put(CacheEnvironment.EXPLICIT_VERSION_CHECK, "true");
+        if (customInstanceLoader != null) {
+            HazelcastMockInstanceFactory.setThreadLocalLoader(customInstanceLoader);
+            props.setProperty("hibernate.cache.hazelcast.factory", "com.hazelcast.hibernate.instance.HazelcastMockInstanceFactory");
+            customInstanceLoader.configure(props);
+        } else {
+            props.remove("hibernate.cache.hazelcast.factory");
+        }
+
+        final Configuration conf = new Configuration();
+        conf.configure(HibernateTestSupport.class.getClassLoader().getResource("test-hibernate.cfg.xml"));
+        addMappings(conf);
+        conf.addProperties(props);
+
+        final SessionFactory sf = conf.buildSessionFactory();
+        sf.getStatistics().setStatisticsEnabled(true);
+
+        return sf;
+    }
+
+    protected HazelcastInstance getHazelcastInstance(final SessionFactory sf) {
+        return HazelcastAccessor.getHazelcastInstance(sf);
+    }
+
+    protected void deleteDummyEntity(SessionFactory sf, long id) throws Exception {
+        Session session = null;
+        Transaction txn = null;
+        try {
+            session = sf.openSession();
+            txn = session.beginTransaction();
+            DummyEntity entityToDelete = session.get(DummyEntity.class, id);
+            session.delete(entityToDelete);
+            txn.commit();
+        } catch (Exception e) {
+            txn.rollback();
+            e.printStackTrace();
+            throw e;
+        } finally {
+            session.close();
+        }
+    }
+
+    protected void executeUpdateQuery(SessionFactory sf, String queryString)
+            throws RuntimeException {
+        Session session = null;
+        Transaction txn = null;
+        try {
+            session = sf.openSession();
+            txn = session.beginTransaction();
+            Query query = session.createQuery(queryString);
+            query.setCacheable(true);
+            query.executeUpdate();
+            txn.commit();
+        } catch (RuntimeException e) {
+            txn.rollback();
+            e.printStackTrace();
+            throw e;
+        } finally {
+            session.close();
+        }
+    }
+
+    protected ArrayList<DummyEntity> getDummyEntities(SessionFactory sf, long untilId) {
+        Session session = sf.openSession();
+        ArrayList<DummyEntity> entities = new ArrayList<DummyEntity>();
+        for (long i=0; i<untilId; i++) {
+            DummyEntity entity = session.get(DummyEntity.class, i);
+            if (entity != null) {
+                session.evict(entity);
+                entities.add(entity);
+            }
+        }
+        session.close();
+        return entities;
+    }
+
+    protected void insertAnnotatedEntities(SessionFactory sf, int count) {
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        for(int i=0; i< count; i++) {
+            AnnotatedEntity annotatedEntity = new AnnotatedEntity("dummy:"+i);
+            session.save(annotatedEntity);
+        }
+        tx.commit();
+        session.close();
+    }
+
+    protected void insertDummyEntities(SessionFactory sf, int count) {
+        insertDummyEntities(sf, count, 0);
+    }
+
+    protected void insertDummyEntities(SessionFactory sf, int count, int childCount) {
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        try {
+            for (int i = 0; i < count; i++) {
+                DummyEntity e = new DummyEntity((long) i, "dummy:" + i, i * 123456d, new Date());
+                session.save(e);
+                for (int j = 0; j < childCount; j++) {
+                    DummyProperty p = new DummyProperty("key:" + j, e);
+                    session.save(p);
+                }
+            }
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            e.printStackTrace();
+        } finally {
+            session.close();
+        }
+    }
+
+    protected void updateDummyEntityName(SessionFactory sf, long id, String newName) {
+        Session session = null;
+        Transaction txn = null;
+        try {
+            session = sf.openSession();
+            txn = session.beginTransaction();
+            DummyEntity entityToUpdate = session.get(DummyEntity.class, id);
+            entityToUpdate.setName(newName);
+            session.update(entityToUpdate);
+            txn.commit();
+        } catch (RuntimeException e) {
+            txn.rollback();
+            e.printStackTrace();
+            throw e;
+        } finally {
+            session.close();
+        }
+    }
+
+    /**
+     * Starting in Hibernate 5, it is no longer possible to set an explicit cache mode for an entity on the
+     * {@code Configuration} object. The cache mode can <i>only</i> be defined in the {@code hbm.xml} file,
+     * for entities configured via XML, or directly on the annotated class.
+     * <p>
+     * To work around that restriction, the {@code hbm.xml} files are treated as templates, with placeholders
+     * for their cache modes. This method opens that template resource, replaces the cache mode and writes it
+     * to a temporary file (which is marked for delete-on-exit to do housekeeping). This way, the test being
+     * run can still control the caching mode.
+     *
+     * @param baseName the base name for the {@code hbm.xml} file to create
+     */
+    private File createHbmXml(final String baseName) {
+        InputStream inputStream = null;
+        BufferedReader reader = null;
+        BufferedWriter writer = null;
+
+        try {
+            inputStream = getClass().getResourceAsStream("/hbm/" + baseName + ".xml");
+            reader = new BufferedReader(new InputStreamReader(inputStream, "UTF-8"));
+
+            final File hbmXmlFile = File.createTempFile(baseName, "hbm.xml");
+            hbmXmlFile.deleteOnExit();
+
+            writer = new BufferedWriter(new FileWriter(hbmXmlFile));
+            for (String line = reader.readLine(); line != null; line = reader.readLine()) {
+                writer.write(String.format(line, getCacheStrategy().getExternalName()));
+                writer.newLine();
+            }
+            writer.flush();
+
+            return hbmXmlFile;
+        } catch (final IOException e) {
+            throw new IllegalStateException("Could not prepare " + baseName + ".hbm.xml", e);
+        } finally {
+            IOUtil.closeResource(writer);
+            IOUtil.closeResource(reader);
+            IOUtil.closeResource(inputStream);
+        }
+    }
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/HibernateTopicTestSupport.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/HibernateTopicTestSupport.java
@@ -1,0 +1,93 @@
+package com.hazelcast.hibernate;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.entity.AnnotatedEntity;
+import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.hibernate.instance.HazelcastMockInstanceLoader;
+import org.hibernate.SessionFactory;
+import org.hibernate.cfg.Environment;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.ArrayList;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+public abstract class HibernateTopicTestSupport extends HibernateTestSupport {
+
+    private final TestHazelcastFactory factory = new TestHazelcastFactory();
+
+    protected final String CACHE_ANNOTATED_ENTITY = AnnotatedEntity.class.getName();
+    protected final String CACHE_ENTITY_PROPERTIES = CACHE_ENTITY + ".properties";
+
+    protected SessionFactory sf;
+
+    private HazelcastInstance instance;
+
+    @Before
+    public void postConstruct() {
+        HazelcastMockInstanceLoader loader = new HazelcastMockInstanceLoader();
+        loader.setInstanceFactory(factory);
+        sf = createSessionFactory(getCacheProperties(),  loader);
+
+        instance = getHazelcastInstance(sf);
+
+        configureTopic(instance);
+    }
+
+    @After
+    public void preDestroy() {
+        if (sf != null) {
+            sf.close();
+            sf = null;
+        }
+        Hazelcast.shutdownAll();
+        factory.shutdownAll();
+    }
+
+    protected abstract void configureTopic(HazelcastInstance instance);
+
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.put("TestAccessType", getCacheStrategy());
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastLocalCacheRegionFactory.class.getName());
+        return props;
+    }
+
+    protected abstract String getTimestampsRegionName();
+
+    protected void insertDummyEntities(int count) {
+        insertDummyEntities(sf, count, 0);
+    }
+
+    protected void insertDummyEntities(int count, int childCount) {
+        insertDummyEntities(sf, count, childCount);
+    }
+
+    protected void insertAnnotatedEntities(int count) {
+        insertAnnotatedEntities(sf, count);
+    }
+
+    protected ArrayList<DummyEntity> getDummyEntities(long untilId) {
+        return getDummyEntities(sf, untilId);
+    }
+
+    protected void updateDummyEntityName(long id, String newName) {
+        updateDummyEntityName(sf, id, newName);
+    }
+
+    protected void deleteDummyEntity(long id) throws Exception {
+        deleteDummyEntity(sf, id);
+    }
+
+    protected void executeUpdateQuery(String queryString) throws RuntimeException {
+        executeUpdateQuery(sf, queryString);
+    }
+
+    protected void assertTopicNotifications(int expectedCount, String topicName) {
+        assertEquals(expectedCount, instance.getTopic(topicName).getLocalTopicStats().getPublishOperationCount());
+    }
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/LocalRegionFactoryDefaultTest.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/LocalRegionFactoryDefaultTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.Environment;
+import org.hibernate.stat.Statistics;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class LocalRegionFactoryDefaultTest extends RegionFactoryDefaultTest {
+
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastLocalCacheRegionFactory.class.getName());
+        return props;
+    }
+
+    @Test
+    public void testEntity() {
+        final HazelcastInstance hz = getHazelcastInstance(sf);
+        assertNotNull(hz);
+        final int count = 100;
+        final int childCount = 3;
+        insertDummyEntities(count, childCount);
+        List<DummyEntity> list = new ArrayList<DummyEntity>(count);
+        Session session = sf.openSession();
+        try {
+            for (int i = 0; i < count; i++) {
+                DummyEntity e = session.get(DummyEntity.class, (long) i);
+                session.evict(e);
+                list.add(e);
+            }
+        } finally {
+            session.close();
+        }
+        session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        try {
+            for (DummyEntity dummy : list) {
+                dummy.setDate(new Date());
+                session.update(dummy);
+            }
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            e.printStackTrace();
+        } finally {
+            session.close();
+        }
+
+        Statistics stats = sf.getStatistics();
+        assertEquals((childCount + 1) * count, stats.getEntityInsertCount());
+        // twice put of entity and properties (on load and update) and once put of collection
+        assertEquals((childCount + 1) * count * 2 + count, stats.getSecondLevelCachePutCount());
+        assertEquals(childCount * count, stats.getEntityLoadCount());
+        assertEquals(count, stats.getSecondLevelCacheHitCount());
+        // collection cache miss
+        assertEquals(count, stats.getSecondLevelCacheMissCount());
+        stats.logSummary();
+    }
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/LocalRegionFactorySlowTest.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/LocalRegionFactorySlowTest.java
@@ -1,0 +1,62 @@
+package com.hazelcast.hibernate;
+
+import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.SlowTest;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.Environment;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
+public class LocalRegionFactorySlowTest extends HibernateSlowTestSupport {
+
+    @Test
+    public void test_query_with_non_mock_network() {
+        final int entityCount = 10;
+        final int queryCount = 2;
+        insertDummyEntities(entityCount);
+        List<DummyEntity> list = null;
+        for (int i = 0; i < queryCount; i++) {
+            list = executeQuery(sf);
+            assertEquals(entityCount, list.size());
+        }
+        for (int i = 0; i < queryCount; i++) {
+            list = executeQuery(sf2);
+            assertEquals(entityCount, list.size());
+        }
+
+        assertNotNull(list);
+        DummyEntity toDelete = list.get(0);
+        Session session = sf2.openSession();
+        Transaction tx = session.beginTransaction();
+        try {
+            session.delete(toDelete);
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            e.printStackTrace();
+        } finally {
+            session.close();
+        }
+        assertEquals(entityCount - 1, executeQuery(sf).size());
+        assertEquals(entityCount - 1, executeQuery(sf2).size());
+
+    }
+
+    @Override
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastLocalCacheRegionFactory.class.getName());
+        return props;
+    }
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/NativeClientTest.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/NativeClientTest.java
@@ -1,0 +1,75 @@
+package com.hazelcast.hibernate;
+
+import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.SlowTest;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Date;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
+public class NativeClientTest
+        extends HibernateSlowTestSupport {
+
+    protected SessionFactory clientSf;
+
+    @Override
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        return props;
+    }
+
+    @Before
+    @Override
+    public void postConstruct() {
+        sf = createSessionFactory(getCacheProperties(), null);
+        clientSf = createClientSessionFactory(getCacheProperties());
+    }
+
+    @Test
+    public void testInsertLoad() {
+        Session session = clientSf.openSession();
+        Transaction tx = session.beginTransaction();
+        DummyEntity e = new DummyEntity((long) 1, "dummy:1", 123456d, new Date());
+        session.save(e);
+        tx.commit();
+        session.close();
+
+        session = clientSf.openSession();
+        DummyEntity retrieved = session.get(DummyEntity.class, (long)1);
+        assertEquals("dummy:1", retrieved.getName());
+    }
+
+    @After
+    public void tearDown() {
+        if(clientSf !=null) {
+            clientSf.close();
+        }
+    }
+
+    protected SessionFactory createClientSessionFactory(Properties props) {
+        Configuration conf = new Configuration();
+        conf.configure(HibernateTestSupport.class.getClassLoader().getResource("test-hibernate-client.cfg.xml"));
+        addHbmMappings(conf);
+        conf.addProperties(props);
+
+        final SessionFactory sf = conf.buildSessionFactory();
+        sf.getStatistics().setStatisticsEnabled(true);
+
+        return sf;
+    }
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/NaturalIdTest.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/NaturalIdTest.java
@@ -1,0 +1,138 @@
+package com.hazelcast.hibernate;
+
+import com.hazelcast.hibernate.entity.AnnotatedEntity;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.SlowTest;
+import org.hibernate.Criteria;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cfg.Environment;
+import org.hibernate.criterion.Restrictions;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category(SlowTest.class)
+public class NaturalIdTest extends HibernateStatisticsTestSupport {
+
+    @Parameterized.Parameters(name = "Executing: {0}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[]{AccessType.READ_WRITE},
+                new Object[]{AccessType.READ_ONLY},
+                new Object[]{AccessType.NONSTRICT_READ_WRITE}
+        );
+    }
+
+    @Parameterized.Parameter(0)
+    public AccessType defaultAccessType;
+
+    @Override
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.put("TestAccessType", defaultAccessType);
+        props.setProperty(Environment.CACHE_REGION_FACTORY, InternalMockRegionFactory.class.getName());
+        return props;
+    }
+
+    @Test
+    public void testNaturalIdCacheEvictsEntityOnUpdate() {
+        Assume.assumeTrue(defaultAccessType == AccessType.READ_WRITE);
+
+        insertAnnotatedEntities(1);
+
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+
+        //1 cache hit since dummy:0 just inserted and still in the cache
+        AnnotatedEntity toBeUpdated = session.byNaturalId(AnnotatedEntity.class).using("title", "dummy:0").getReference();
+        toBeUpdated.setTitle("dummy101");
+        tx.commit();
+        session.close();
+
+        assertEquals(1, sf.getStatistics().getNaturalIdCacheHitCount());
+
+        //dummy:0 should be evicted and this leads to a cache miss
+        session = sf.openSession();
+        Criteria criteria = session.createCriteria(AnnotatedEntity.class).add(Restrictions.naturalId().set("title","dummy:0"))
+                                   .setCacheable(true);
+        criteria.uniqueResult();
+
+        assertEquals(1, sf.getStatistics().getNaturalIdCacheMissCount());
+    }
+
+    @Test
+    public void testNaturalIdCacheStillHitsAfterIrrelevantNaturalIdUpdate() {
+        Assume.assumeTrue(defaultAccessType == AccessType.READ_WRITE);
+
+        insertAnnotatedEntities(2);
+
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+
+        //1 cache hit since dummy:1 just inserted and still in the cache
+        AnnotatedEntity toBeUpdated = session.byNaturalId(AnnotatedEntity.class).using("title", "dummy:1").getReference();
+        toBeUpdated.setTitle("dummy101");
+        tx.commit();
+        session.close();
+
+        assertEquals(1, sf.getStatistics().getNaturalIdCacheHitCount());
+
+        //only dummy:1 should be evicted from cache on contrary to behavior of hibernate query cache without natural ids
+        session = sf.openSession();
+        Criteria criteria = session.createCriteria(AnnotatedEntity.class).add(Restrictions.naturalId().set("title","dummy:0"))
+                                   .setCacheable(true);
+        criteria.uniqueResult();
+
+        //cache hit dummy:0 + previous hit
+        assertEquals(2, sf.getStatistics().getNaturalIdCacheHitCount());
+    }
+
+    @Test
+    public void testFindByNaturalId() {
+        insertAnnotatedEntities(1);
+        Session session = sf.openSession();
+
+        AnnotatedEntity toBeUpdated = session.byNaturalId(AnnotatedEntity.class).using("title", "dummy:0").getReference();
+        assertEquals("dummy:0", toBeUpdated.getTitle());
+        session.close();
+    }
+
+    @Test
+    public void testEvictionNaturalId() {
+        insertAnnotatedEntities(1);
+        sf.getCache().evictNaturalIdRegion(AnnotatedEntity.class);
+        assertFalse(sf.getCache().containsEntity(AnnotatedEntity.class, 0L));
+    }
+
+    public static class InternalMockRegionFactory
+            extends HazelcastCacheRegionFactory {
+
+        private AccessType defaultAccessType;
+
+        public InternalMockRegionFactory() {
+            super();
+        }
+
+        public InternalMockRegionFactory(final Properties properties) {
+            super(properties);
+            defaultAccessType = (AccessType) properties.get("TestAccessType");
+        }
+
+        @Override
+        public AccessType getDefaultAccessType() {
+            return defaultAccessType;
+        }
+    }
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultSlowTest.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultSlowTest.java
@@ -29,7 +29,9 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -59,9 +61,10 @@ public class RegionFactoryDefaultSlowTest
 
         HazelcastQueryResultsRegion queryRegion = ((HazelcastQueryResultsRegion) (((SessionFactoryImpl) sf).getQueryCache()).getRegion());
         assertEquals(numberOfEntities, queryRegion.getCache().size());
-        sleep(defaultCleanupPeriod);
 
-        assertEquals(numberOfEntities - evictedItemCount, queryRegion.getCache().size());
+        await()
+          .atMost(defaultCleanupPeriod + 1, TimeUnit.SECONDS)
+          .until(() -> (numberOfEntities - evictedItemCount) == queryRegion.getCache().size());
     }
 
     @Test

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultSlowTest.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultSlowTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.hibernate.region.HazelcastQueryResultsRegion;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.SlowTest;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.Environment;
+import org.hibernate.internal.SessionFactoryImpl;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
+public class RegionFactoryDefaultSlowTest
+        extends HibernateSlowTestSupport {
+
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        return props;
+    }
+
+    @Test
+    public void testQueryCacheCleanup() {
+
+        MapConfig mapConfig = getHazelcastInstance(sf).getConfig().getMapConfig("org.hibernate.cache.*");
+        final float baseEvictionRate = 0.2f;
+        final int numberOfEntities = 100;
+        final int defaultCleanupPeriod = 60;
+        final int maxSize = mapConfig.getEvictionConfig().getSize();
+        final int evictedItemCount = numberOfEntities - maxSize + (int) (maxSize * baseEvictionRate);
+        insertDummyEntities(numberOfEntities);
+        for (int i = 0; i < numberOfEntities; i++) {
+            executeQuery(sf, i);
+        }
+
+        HazelcastQueryResultsRegion queryRegion = ((HazelcastQueryResultsRegion) (((SessionFactoryImpl) sf).getQueryCache()).getRegion());
+        assertEquals(numberOfEntities, queryRegion.getCache().size());
+        sleep(defaultCleanupPeriod);
+
+        assertEquals(numberOfEntities - evictedItemCount, queryRegion.getCache().size());
+    }
+
+    @Test
+    public void testUpdateEntity() {
+        final long dummyId = 0;
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        session.save(new DummyEntity(dummyId, null, 0, null));
+        tx.commit();
+
+        tx = session.beginTransaction();
+        DummyEntity ent = (DummyEntity) session.get(DummyEntity.class, dummyId);
+        ent.setName("updatedName");
+        session.update(ent);
+        tx.commit();
+        session.close();
+
+        session = sf2.openSession();
+        DummyEntity entity = (DummyEntity) session.get(DummyEntity.class, dummyId);
+        assertEquals("updatedName", entity.getName());
+    }
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultTest.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.hibernate.engine.spi.CacheImplementor;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class RegionFactoryDefaultTest extends RegionFactoryDefaultTestSupport {
+
+    @Override
+    protected void clearTimestampsCache() {
+        ((CacheImplementor) sf.getCache()).getUpdateTimestampsCache().clear();
+    }
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultTestSupport.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultTestSupport.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.hibernate.entity.DummyProperty;
+import org.hibernate.Query;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.Environment;
+import org.hibernate.stat.Statistics;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+public abstract class RegionFactoryDefaultTestSupport extends HibernateStatisticsTestSupport {
+
+    protected abstract void clearTimestampsCache();
+
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        return props;
+    }
+
+    @Test
+    public void testEntity() {
+        final HazelcastInstance hz = getHazelcastInstance(sf);
+        assertNotNull(hz);
+        final int count = 100;
+        final int childCount = 3;
+        insertDummyEntities(count, childCount);
+        List<DummyEntity> list = new ArrayList<DummyEntity>(count);
+        Session session = sf.openSession();
+        try {
+            for (int i = 0; i < count; i++) {
+                DummyEntity e = session.get(DummyEntity.class, (long) i);
+                session.evict(e);
+                list.add(e);
+            }
+        } finally {
+            session.close();
+        }
+        session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        try {
+            for (DummyEntity dummy : list) {
+                dummy.setDate(new Date());
+                session.update(dummy);
+            }
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            e.printStackTrace();
+        } finally {
+            session.close();
+        }
+
+        Statistics stats = sf.getStatistics();
+        Map<?, ?> cache = hz.getMap(DummyEntity.class.getName());
+        Map<?, ?> propCache = hz.getMap(DummyProperty.class.getName());
+        Map<?, ?> propCollCache = hz.getMap(DummyEntity.class.getName() + ".properties");
+        assertEquals((childCount + 1) * count, stats.getEntityInsertCount());
+        // twice put of entity and properties (on load and update) and once put of collection
+        // TODO: fix next assertion ->
+        //        assertEquals((childCount + 1) * count * 2, stats.getSecondLevelCachePutCount());
+        assertEquals(childCount * count, stats.getEntityLoadCount());
+        assertEquals(count, stats.getSecondLevelCacheHitCount());
+        // collection cache miss
+        assertEquals(count, stats.getSecondLevelCacheMissCount());
+        assertEquals(count, cache.size());
+        assertEquals(count * childCount, propCache.size());
+        assertEquals(count, propCollCache.size());
+        sf.getCache().evictEntityRegion(DummyEntity.class);
+        sf.getCache().evictEntityRegion(DummyProperty.class);
+        assertEquals(0, cache.size());
+        assertEquals(0, propCache.size());
+        stats.logSummary();
+    }
+
+    @Test
+    public void testQuery() {
+        final int entityCount = 10;
+        final int queryCount = 3;
+        insertDummyEntities(entityCount);
+
+        // Clear the caches after inserting the entities (to avoid scenarios where the timestamps cache may or may not
+        // be out of date, leading to a different number of cache hits and misses).
+        sf.getCache().evictAllRegions();
+        clearTimestampsCache();
+
+        List<DummyEntity> list = null;
+        for (int i = 0; i < queryCount; i++) {
+            list = executeQuery();
+            assertEquals(entityCount, list.size());
+        }
+
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        try {
+            for (DummyEntity dummy : list) {
+                session.delete(dummy);
+            }
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            e.printStackTrace();
+        } finally {
+            session.close();
+        }
+
+        Statistics stats = sf.getStatistics();
+        assertEquals(1, stats.getQueryCachePutCount());
+        assertEquals(1, stats.getQueryCacheMissCount());
+        assertEquals(queryCount - 1, stats.getQueryCacheHitCount());
+        assertEquals(1, stats.getQueryExecutionCount());
+        assertEquals(entityCount, stats.getEntityInsertCount());
+        //      FIXME
+        //      HazelcastRegionFactory puts into L2 cache 2 times; 1 on insert, 1 on query execution
+        //      assertEquals(entityCount, stats.getSecondLevelCachePutCount());
+        assertEquals(entityCount, stats.getEntityLoadCount());
+        assertEquals(entityCount * (queryCount - 1) * 2, stats.getSecondLevelCacheHitCount());
+        // collection cache miss
+        assertEquals(entityCount, stats.getSecondLevelCacheMissCount());
+        assertEquals(entityCount, stats.getEntityDeleteCount());
+        stats.logSummary();
+    }
+
+    @Test
+    public void testSpecificQueryRegionEviction() {
+        int entityCount = 10;
+        insertDummyEntities(entityCount, 0);
+
+        //miss 1 query list entities
+        Session session = sf.openSession();
+        Transaction txn = session.beginTransaction();
+        Query query = session.createQuery("from " + DummyEntity.class.getName());
+        query.setCacheable(true).setCacheRegion("newregionname");
+        query.list();
+        txn.commit();
+        session.close();
+        //query is cached
+
+        //query is invalidated
+        sf.getCache().evictQueryRegion("newregionname");
+
+        //miss 1 query
+        session = sf.openSession();
+        txn = session.beginTransaction();
+        query = session.createQuery("from " + DummyEntity.class.getName());
+        query.setCacheable(true);
+        query.list();
+        txn.commit();
+        session.close();
+
+        assertEquals(0, sf.getStatistics().getQueryCacheHitCount());
+        assertEquals(2, sf.getStatistics().getQueryCacheMissCount());
+    }
+
+    @Test
+    public void testInsertGetUpdateGet() {
+        Session session = sf.openSession();
+        DummyEntity e = new DummyEntity(1L, "test", 0d, null);
+        Transaction tx = session.beginTransaction();
+        try {
+            session.save(e);
+            tx.commit();
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            tx.rollback();
+            Assert.fail(ex.getMessage());
+        } finally {
+            session.close();
+        }
+
+        session = sf.openSession();
+        try {
+            e = session.get(DummyEntity.class, 1L);
+            assertEquals("test", e.getName());
+            assertNull(e.getDate());
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            Assert.fail(ex.getMessage());
+        } finally {
+            session.close();
+        }
+
+        session = sf.openSession();
+        tx = session.beginTransaction();
+        try {
+            e = session.get(DummyEntity.class, 1L);
+            assertEquals("test", e.getName());
+            assertNull(e.getDate());
+            e.setName("dummy");
+            e.setDate(new Date());
+            session.update(e);
+            tx.commit();
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            tx.rollback();
+            Assert.fail(ex.getMessage());
+        } finally {
+            session.close();
+        }
+
+        session = sf.openSession();
+        try {
+            e = session.get(DummyEntity.class, 1L);
+            assertEquals("dummy", e.getName());
+            Assert.assertNotNull(e.getDate());
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            Assert.fail(ex.getMessage());
+        } finally {
+            session.close();
+        }
+    }
+
+    @Test
+    public void testEvictionEntity() {
+        insertDummyEntities(1, 1);
+        sf.getCache().evictEntity("com.hazelcast.hibernate.entity.DummyEntity", 0L);
+        assertFalse(sf.getCache().containsEntity("com.hazelcast.hibernate.entity.DummyEntity", 0L));
+    }
+
+    @Test
+    public void testEvictionCollection() {
+        insertDummyEntities(1, 1);
+        sf.getCache().evictCollection("com.hazelcast.hibernate.entity.DummyEntity.properties", 0L);
+        assertFalse(sf.getCache().containsCollection("com.hazelcast.hibernate.entity.DummyEntity.properties", 0L));
+    }
+
+    @Test
+    public void testInsertEvictUpdate() {
+        insertDummyEntities(1);
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        DummyEntity ent = session.get(DummyEntity.class, 0L);
+        sf.getCache().evictEntity("com.hazelcast.hibernate.entity.DummyEntity", 0L);
+        ent.setName("updatedName");
+        session.update(ent);
+        tx.commit();
+        session.close();
+        ArrayList<DummyEntity> list = getDummyEntities(1);
+        assertEquals("updatedName", list.get(0).getName());
+    }
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/RegionFactoryQueryTest.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/RegionFactoryQueryTest.java
@@ -1,0 +1,69 @@
+package com.hazelcast.hibernate;
+
+import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.SlowTest;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.Environment;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
+public class RegionFactoryQueryTest extends HibernateSlowTestSupport{
+
+    @Before
+    @Override
+    public void postConstruct() {
+        sf = createSessionFactory(getCacheProperties(), null);
+        sf2 = createSessionFactory(getCacheProperties(), null);
+    }
+
+    @Test
+    public void test_query_with_non_mock_network() {
+        final int entityCount = 10;
+        final int queryCount = 2;
+        insertDummyEntities(entityCount);
+        List<DummyEntity> list = null;
+        for (int i = 0; i < queryCount; i++) {
+            list = executeQuery(sf);
+            assertEquals(entityCount, list.size());
+        }
+        for (int i = 0; i < queryCount; i++) {
+            list = executeQuery(sf2);
+            assertEquals(entityCount, list.size());
+        }
+
+        assertNotNull(list);
+        DummyEntity toDelete = list.get(0);
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        try {
+            session.delete(toDelete);
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            e.printStackTrace();
+        } finally {
+            session.close();
+        }
+        assertEquals(entityCount - 1, executeQuery(sf).size());
+        assertEquals(entityCount - 1, executeQuery(sf2).size());
+
+    }
+
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        return props;
+    }
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/TopicNonStrictReadWriteTest.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/TopicNonStrictReadWriteTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.local.LocalRegionCache;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.SlowTest;
+import org.hibernate.cache.spi.UpdateTimestampsCache;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
+public class TopicNonStrictReadWriteTest extends TopicNonStrictReadWriteTestSupport {
+
+    @Override
+    protected void configureTopic(HazelcastInstance instance) {
+        // Construct a LocalRegionCache instance, which configures the topic
+        new LocalRegionCache("cache", instance, null, true);
+    }
+
+    @Override
+    protected String getTimestampsRegionName() {
+        return UpdateTimestampsCache.REGION_NAME;
+    }
+
+    @Test
+    public void testUpdateQueryByNaturalId() {
+        insertAnnotatedEntities(2);
+
+        executeUpdateQuery("update AnnotatedEntity set title = 'updated-name' where title = 'dummy:1'");
+
+        assertTopicNotifications(1, CACHE_ANNOTATED_ENTITY + "##NaturalId");
+        assertTopicNotifications(4, getTimestampsRegionName());
+    }
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/TopicNonStrictReadWriteTestSupport.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/TopicNonStrictReadWriteTestSupport.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.hibernate.entity.AnnotatedEntity;
+import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.hibernate.entity.DummyProperty;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.Query;
+import org.junit.Test;
+
+import java.util.HashSet;
+
+public abstract class TopicNonStrictReadWriteTestSupport extends HibernateTopicTestSupport {
+
+    @Test
+    public void testReplaceCollection() {
+        insertDummyEntities(2, 4);
+
+        Session session = sf.openSession();
+        Transaction transaction = session.beginTransaction();
+
+        DummyProperty property = new DummyProperty("somekey");
+        session.save(property);
+
+        DummyEntity entity = session.get(DummyEntity.class, 1L);
+        HashSet<DummyProperty> updatedProperties = new HashSet<DummyProperty>();
+        updatedProperties.add(property);
+        entity.setProperties(updatedProperties);
+
+        session.update(entity);
+
+        transaction.commit();
+        session.close();
+
+        assertTopicNotifications(2, CACHE_ENTITY);
+        assertTopicNotifications(4, CACHE_ENTITY_PROPERTIES);
+        assertTopicNotifications(18, getTimestampsRegionName());
+    }
+
+    @Test
+    public void testUpdateOneEntityByNaturalId() {
+        insertAnnotatedEntities(2);
+
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+
+        AnnotatedEntity toBeUpdated = session.byNaturalId(AnnotatedEntity.class).using("title", "dummy:1").getReference();
+        toBeUpdated.setTitle("dummy101");
+        tx.commit();
+        session.close();
+
+        assertTopicNotifications(2, CACHE_ANNOTATED_ENTITY + "##NaturalId");
+        assertTopicNotifications(4, getTimestampsRegionName());
+    }
+
+    @Test
+    public void testUpdateEntitiesByNaturalId() {
+        insertAnnotatedEntities(2);
+
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+
+        AnnotatedEntity toBeUpdated = session.byNaturalId(AnnotatedEntity.class).using("title", "dummy:1").getReference();
+        toBeUpdated.setTitle("dummy101");
+
+        AnnotatedEntity toBeUpdated2 = session.byNaturalId(AnnotatedEntity.class).using("title", "dummy:0").getReference();
+        toBeUpdated2.setTitle("dummy100");
+        tx.commit();
+        session.close();
+
+        // 5 notifications = 1 eviction, plus for each update: one unlockItem and one afterUpdate
+        assertTopicNotifications(5, CACHE_ANNOTATED_ENTITY + "##NaturalId");
+        assertTopicNotifications(4, getTimestampsRegionName());
+    }
+
+    @Test
+    public void testDeleteOneEntityByNaturalId() {
+        insertAnnotatedEntities(2);
+
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+
+        AnnotatedEntity toBeDeleted = session.byNaturalId(AnnotatedEntity.class).using("title", "dummy:1").getReference();
+        session.delete(toBeDeleted);
+        tx.commit();
+        session.close();
+
+        assertTopicNotifications(2, CACHE_ANNOTATED_ENTITY + "##NaturalId");
+        assertTopicNotifications(4, getTimestampsRegionName());
+    }
+
+    @Test
+    public void testDeleteEntitiesByNaturalId() {
+        insertAnnotatedEntities(2);
+
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+
+        AnnotatedEntity toBeDeleted = session.byNaturalId(AnnotatedEntity.class).using("title", "dummy:1").getReference();
+        session.delete(toBeDeleted);
+
+        AnnotatedEntity toBeDeleted2 = session.byNaturalId(AnnotatedEntity.class).using("title", "dummy:0").getReference();
+        session.delete(toBeDeleted2);
+        tx.commit();
+        session.close();
+
+        assertTopicNotifications(4, CACHE_ANNOTATED_ENTITY + "##NaturalId");
+        assertTopicNotifications(4, getTimestampsRegionName());
+    }
+
+    @Test
+    public void testDeleteOneEntity() throws Exception {
+        insertDummyEntities(1, 1);
+
+        deleteDummyEntity(0);
+
+        assertTopicNotifications(2, CACHE_ENTITY);
+        assertTopicNotifications(2, CACHE_ENTITY_PROPERTIES);
+        assertTopicNotifications(2, CACHE_PROPERTY);
+        assertTopicNotifications(9, getTimestampsRegionName());
+    }
+
+    @Test
+    public void testDeleteEntities() throws Exception {
+        insertDummyEntities(10, 4);
+
+        for (int i = 0; i < 3; i++) {
+            deleteDummyEntity(i);
+        }
+
+        assertTopicNotifications(6, CACHE_ENTITY);
+        assertTopicNotifications(6, CACHE_ENTITY_PROPERTIES);
+        assertTopicNotifications(24, CACHE_PROPERTY);
+        assertTopicNotifications(67, getTimestampsRegionName());
+    }
+
+    @Test
+    public void testUpdateOneEntity() {
+        insertDummyEntities(10, 4);
+
+        getDummyEntities(10);
+
+        updateDummyEntityName(2, "updated");
+
+        assertTopicNotifications(2, CACHE_ENTITY);
+        assertTopicNotifications(0, CACHE_ENTITY_PROPERTIES);
+        assertTopicNotifications(0, CACHE_PROPERTY);
+        assertTopicNotifications(54, getTimestampsRegionName());
+    }
+
+    @Test
+    public void testUpdateEntities() {
+        insertDummyEntities(1, 10);
+
+        executeUpdateQuery("update DummyEntity set name = 'updated-name' where id < 2");
+
+        assertTopicNotifications(2, CACHE_ENTITY);
+        assertTopicNotifications(0, CACHE_ENTITY_PROPERTIES);
+        assertTopicNotifications(0, CACHE_PROPERTY);
+        assertTopicNotifications(15, getTimestampsRegionName());
+    }
+
+    @Test
+    public void testUpdateEntitiesAndProperties() {
+        insertDummyEntities(1, 10);
+
+        Session session = null;
+        Transaction txn = null;
+        try {
+            session = sf.openSession();
+            txn = session.beginTransaction();
+            Query query = session.createQuery("update DummyEntity set name = 'updated-name' where id < 2");
+            query.setCacheable(true);
+            query.executeUpdate();
+
+            Query query2 = session.createQuery("update DummyProperty set version = version + 1");
+            query2.setCacheable(true);
+            query2.executeUpdate();
+
+            txn.commit();
+        } catch (RuntimeException e) {
+            txn.rollback();
+            e.printStackTrace();
+            throw e;
+        } finally {
+            session.close();
+        }
+
+        assertTopicNotifications(2, CACHE_ENTITY);
+        assertTopicNotifications(2, CACHE_ENTITY_PROPERTIES);
+        assertTopicNotifications(2, CACHE_PROPERTY);
+        assertTopicNotifications(17, getTimestampsRegionName());
+    }
+
+    @Test
+    public void testUpdateOneEntityAndProperties() {
+        insertDummyEntities(1, 10);
+
+        Session session = null;
+        Transaction txn = null;
+        try {
+            session = sf.openSession();
+            txn = session.beginTransaction();
+            Query query = session.createQuery("update DummyEntity set name = 'updated-name' where id = 0");
+            query.setCacheable(true);
+            query.executeUpdate();
+
+            Query query2 = session.createQuery("update DummyProperty set version = version + 1");
+            query2.setCacheable(true);
+            query2.executeUpdate();
+
+            txn.commit();
+        } catch (RuntimeException e) {
+            txn.rollback();
+            e.printStackTrace();
+            throw e;
+        } finally {
+            session.close();
+        }
+
+        assertTopicNotifications(2, CACHE_ENTITY);
+        assertTopicNotifications(2, CACHE_ENTITY_PROPERTIES);
+        assertTopicNotifications(2, CACHE_PROPERTY);
+        assertTopicNotifications(17, getTimestampsRegionName());
+    }
+
+    @Override
+    protected AccessType getCacheStrategy() {
+        return AccessType.NONSTRICT_READ_WRITE;
+    }
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/TopicReadOnlyTest.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/TopicReadOnlyTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.local.LocalRegionCache;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.SlowTest;
+import org.hibernate.Query;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.cache.spi.UpdateTimestampsCache;
+import org.hibernate.cache.spi.access.AccessType;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
+public class TopicReadOnlyTest extends TopicReadOnlyTestSupport {
+
+    @Override
+    protected void configureTopic(HazelcastInstance instance) {
+        // Construct a LocalRegionCache instance, which configures the topic
+        new LocalRegionCache("cache", instance, null, true);
+    }
+
+    @Override
+    protected String getTimestampsRegionName() {
+        return UpdateTimestampsCache.REGION_NAME;
+    }
+
+    @Test
+    public void testUpdateQueryByNaturalId() {
+        insertAnnotatedEntities(2);
+
+        executeUpdateQuery("update AnnotatedEntity set title = 'updated-name' where title = 'dummy:1'");
+
+        assertTopicNotifications(1, CACHE_ANNOTATED_ENTITY + "##NaturalId");
+        assertTopicNotifications(4, getTimestampsRegionName());
+    }
+
+    @Test
+    public void testDeleteOneEntity() throws Exception {
+        insertDummyEntities(1, 1);
+
+        deleteDummyEntity(0);
+
+        assertTopicNotifications(2, CACHE_ENTITY);
+        assertTopicNotifications(2, CACHE_ENTITY_PROPERTIES);
+        assertTopicNotifications(2, CACHE_PROPERTY);
+        assertTopicNotifications(9, getTimestampsRegionName());
+    }
+
+    @Test
+    public void testDeleteEntities() throws Exception {
+        insertDummyEntities(10, 4);
+
+        for (int i = 0; i < 3; i++) {
+            deleteDummyEntity(i);
+        }
+
+        assertTopicNotifications(6, CACHE_ENTITY);
+        assertTopicNotifications(6, CACHE_ENTITY_PROPERTIES);
+        assertTopicNotifications(24, CACHE_PROPERTY);
+        assertTopicNotifications(67, getTimestampsRegionName());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testUpdateEntities() {
+        insertDummyEntities(1, 10);
+
+        executeUpdateQuery("update DummyEntity set name = 'updated-name' where id < 2");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testUpdateEntitiesAndProperties() {
+        insertDummyEntities(1, 10);
+
+        Session session = null;
+        Transaction txn = null;
+        try {
+            session = sf.openSession();
+            txn = session.beginTransaction();
+            Query query = session.createQuery("update DummyEntity set name = 'updated-name' where id < 2");
+            query.setCacheable(true);
+            query.executeUpdate();
+
+            Query query2 = session.createQuery("update DummyProperty set version = version + 1");
+            query2.setCacheable(true);
+            query2.executeUpdate();
+
+            txn.commit();
+        } catch (RuntimeException e) {
+            txn.rollback();
+            e.printStackTrace();
+            throw e;
+        } finally {
+            session.close();
+        }
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testUpdateOneEntityAndProperties() {
+        insertDummyEntities(1, 10);
+
+        Session session = null;
+        Transaction txn = null;
+        try {
+            session = sf.openSession();
+            txn = session.beginTransaction();
+            Query query = session.createQuery("update DummyEntity set name = 'updated-name' where id = 0");
+            query.setCacheable(true);
+            query.executeUpdate();
+
+            Query query2 = session.createQuery("update DummyProperty set version = version + 1");
+            query2.setCacheable(true);
+            query2.executeUpdate();
+
+            txn.commit();
+        } catch (RuntimeException e) {
+            txn.rollback();
+            e.printStackTrace();
+            throw e;
+        } finally {
+            session.close();
+        }
+    }
+
+    protected AccessType getCacheStrategy() {
+        return AccessType.READ_ONLY;
+    }
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/TopicReadOnlyTestSupport.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/TopicReadOnlyTestSupport.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.hibernate.entity.AnnotatedEntity;
+import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.hibernate.entity.DummyProperty;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.cache.spi.access.AccessType;
+import org.junit.Test;
+
+import java.util.HashSet;
+
+public abstract class TopicReadOnlyTestSupport extends HibernateTopicTestSupport {
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testReplaceCollection() {
+        insertDummyEntities(2, 4);
+
+        Session session = sf.openSession();
+        Transaction transaction = session.beginTransaction();
+
+        DummyProperty property = new DummyProperty("somekey");
+        session.save(property);
+
+        DummyEntity entity = session.get(DummyEntity.class, 1L);
+        HashSet<DummyProperty> updatedProperties = new HashSet<DummyProperty>();
+        updatedProperties.add(property);
+        entity.setProperties(updatedProperties);
+
+        session.update(entity);
+
+        transaction.commit();
+        session.close();
+    }
+
+    @Test
+    public void testUpdateOneEntityByNaturalId() {
+        insertAnnotatedEntities(2);
+
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+
+        AnnotatedEntity toBeUpdated = session.byNaturalId(AnnotatedEntity.class).using("title", "dummy:1").getReference();
+        toBeUpdated.setTitle("dummy101");
+        tx.commit();
+        session.close();
+
+        assertTopicNotifications(2, CACHE_ANNOTATED_ENTITY + "##NaturalId");
+        assertTopicNotifications(4, getTimestampsRegionName());
+    }
+
+    @Test
+    public void testUpdateEntitiesByNaturalId() {
+        insertAnnotatedEntities(2);
+
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+
+        AnnotatedEntity toBeUpdated = session.byNaturalId(AnnotatedEntity.class).using("title", "dummy:1").getReference();
+        toBeUpdated.setTitle("dummy101");
+
+        AnnotatedEntity toBeUpdated2 = session.byNaturalId(AnnotatedEntity.class).using("title", "dummy:0").getReference();
+        toBeUpdated2.setTitle("dummy100");
+        tx.commit();
+        session.close();
+
+        // 5 notifications = 1 eviction, plus for each update: one unlockItem and one afterUpdate
+        assertTopicNotifications(5, CACHE_ANNOTATED_ENTITY + "##NaturalId");
+        assertTopicNotifications(4, getTimestampsRegionName());
+    }
+
+    @Test
+    public void testDeleteOneEntityByNaturalId() {
+        insertAnnotatedEntities(2);
+
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+
+        AnnotatedEntity toBeDeleted = session.byNaturalId(AnnotatedEntity.class).using("title", "dummy:1").getReference();
+        session.delete(toBeDeleted);
+        tx.commit();
+        session.close();
+
+        assertTopicNotifications(2, CACHE_ANNOTATED_ENTITY + "##NaturalId");
+        assertTopicNotifications(4, getTimestampsRegionName());
+    }
+
+    @Test
+    public void testDeleteEntitiesByNaturalId() {
+        insertAnnotatedEntities(2);
+
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+
+        AnnotatedEntity toBeDeleted = session.byNaturalId(AnnotatedEntity.class).using("title", "dummy:1").getReference();
+        session.delete(toBeDeleted);
+
+        AnnotatedEntity toBeDeleted2 = session.byNaturalId(AnnotatedEntity.class).using("title", "dummy:0").getReference();
+        session.delete(toBeDeleted2);
+        tx.commit();
+        session.close();
+
+        assertTopicNotifications(4, CACHE_ANNOTATED_ENTITY + "##NaturalId");
+        assertTopicNotifications(4, getTimestampsRegionName());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testUpdateOneEntity() {
+        insertDummyEntities(10, 4);
+
+        getDummyEntities(10);
+
+        updateDummyEntityName(2, "updated");
+    }
+
+    @Override
+    protected AccessType getCacheStrategy() {
+        return AccessType.READ_ONLY;
+    }
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/TopicReadWriteTest.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/TopicReadWriteTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.local.LocalRegionCache;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.SlowTest;
+import org.hibernate.Query;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.cache.spi.UpdateTimestampsCache;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
+public class TopicReadWriteTest extends TopicReadWriteTestSupport {
+
+    @Override
+    protected void configureTopic(HazelcastInstance instance) {
+        // Construct a LocalRegionCache instance, which configures the topic
+        new LocalRegionCache("cache", instance, null, true);
+    }
+
+    @Override
+    protected String getTimestampsRegionName() {
+        return UpdateTimestampsCache.REGION_NAME;
+    }
+
+    @Test
+    public void testUpdateQueryByNaturalId() {
+        insertAnnotatedEntities(2);
+
+        executeUpdateQuery("update AnnotatedEntity set title = 'updated-name' where title = 'dummy:1'");
+
+        assertTopicNotifications(1, CACHE_ANNOTATED_ENTITY + "##NaturalId");
+        assertTopicNotifications(4, getTimestampsRegionName());
+    }
+
+    @Test
+    public void testUpdateEntitiesAndProperties() {
+        insertDummyEntities(1, 10);
+
+        Session session = null;
+        Transaction txn = null;
+        try {
+            session = sf.openSession();
+            txn = session.beginTransaction();
+            Query query = session.createQuery("update DummyEntity set name = 'updated-name' where id < 2");
+            query.setCacheable(true);
+            query.executeUpdate();
+
+            Query query2 = session.createQuery("update DummyProperty set version = version + 1");
+            query2.setCacheable(true);
+            query2.executeUpdate();
+
+            txn.commit();
+        } catch (RuntimeException e) {
+            txn.rollback();
+            e.printStackTrace();
+            throw e;
+        } finally {
+            session.close();
+        }
+
+        assertTopicNotifications(1, CACHE_ENTITY);
+        assertTopicNotifications(1, CACHE_ENTITY_PROPERTIES);
+        assertTopicNotifications(1, CACHE_PROPERTY);
+        assertTopicNotifications(17, getTimestampsRegionName());
+    }
+
+    @Test
+    public void testUpdateOneEntityAndProperties() {
+        insertDummyEntities(1, 10);
+
+        Session session = null;
+        Transaction txn = null;
+        try {
+            session = sf.openSession();
+            txn = session.beginTransaction();
+            Query query = session.createQuery("update DummyEntity set name = 'updated-name' where id = 0");
+            query.setCacheable(true);
+            query.executeUpdate();
+
+            Query query2 = session.createQuery("update DummyProperty set version = version + 1");
+            query2.setCacheable(true);
+            query2.executeUpdate();
+
+            txn.commit();
+        } catch (RuntimeException e) {
+            txn.rollback();
+            e.printStackTrace();
+            throw e;
+        } finally {
+            session.close();
+        }
+
+        assertTopicNotifications(1, CACHE_ENTITY);
+        assertTopicNotifications(1, CACHE_ENTITY_PROPERTIES);
+        assertTopicNotifications(1, CACHE_PROPERTY);
+        assertTopicNotifications(17, getTimestampsRegionName());
+    }
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/TopicReadWriteTestSupport.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/TopicReadWriteTestSupport.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.hibernate.entity.AnnotatedEntity;
+import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.hibernate.entity.DummyProperty;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.cache.spi.access.AccessType;
+
+import org.junit.Test;
+
+import java.util.*;
+
+public abstract class TopicReadWriteTestSupport extends HibernateTopicTestSupport {
+
+    @Test
+    public void testReplaceCollection() {
+        insertDummyEntities(2, 4);
+
+        Session session = sf.openSession();
+        Transaction transaction = session.beginTransaction();
+
+        DummyProperty property = new DummyProperty("somekey");
+        session.save(property);
+
+        DummyEntity entity = session.get(DummyEntity.class, 1L);
+        HashSet<DummyProperty> updatedProperties = new HashSet<DummyProperty>();
+        updatedProperties.add(property);
+        entity.setProperties(updatedProperties);
+
+        session.update(entity);
+
+        transaction.commit();
+        session.close();
+
+        assertTopicNotifications(1, CACHE_ENTITY);
+        assertTopicNotifications(2, CACHE_ENTITY_PROPERTIES);
+        assertTopicNotifications(18, getTimestampsRegionName());
+    }
+
+    @Test
+    public void testUpdateOneEntityByNaturalId() {
+        insertAnnotatedEntities(2);
+
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+
+        AnnotatedEntity toBeUpdated = session.byNaturalId(AnnotatedEntity.class).using("title", "dummy:1").getReference();
+        toBeUpdated.setTitle("dummy101");
+        tx.commit();
+        session.close();
+
+        assertTopicNotifications(2, CACHE_ANNOTATED_ENTITY + "##NaturalId");
+        assertTopicNotifications(4, getTimestampsRegionName());
+    }
+
+    @Test
+    public void testUpdateEntitiesByNaturalId() {
+        insertAnnotatedEntities(2);
+
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+
+        AnnotatedEntity toBeUpdated = session.byNaturalId(AnnotatedEntity.class).using("title", "dummy:1").getReference();
+        toBeUpdated.setTitle("dummy101");
+
+        AnnotatedEntity toBeUpdated2 = session.byNaturalId(AnnotatedEntity.class).using("title", "dummy:0").getReference();
+        toBeUpdated2.setTitle("dummy100");
+        tx.commit();
+        session.close();
+
+        // 5 notifications = 1 eviction, plus for each update: one unlockItem and one afterUpdate
+        assertTopicNotifications(5, CACHE_ANNOTATED_ENTITY + "##NaturalId");
+        assertTopicNotifications(4, getTimestampsRegionName());
+    }
+
+    @Test
+    public void testDeleteOneEntityByNaturalId() {
+        insertAnnotatedEntities(2);
+
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+
+        AnnotatedEntity toBeDeleted = session.byNaturalId(AnnotatedEntity.class).using("title", "dummy:1").getReference();
+        session.delete(toBeDeleted);
+        tx.commit();
+        session.close();
+
+        assertTopicNotifications(2, CACHE_ANNOTATED_ENTITY + "##NaturalId");
+        assertTopicNotifications(4, getTimestampsRegionName());
+    }
+
+    @Test
+    public void testDeleteEntitiesByNaturalId() {
+        insertAnnotatedEntities(2);
+
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+
+        AnnotatedEntity toBeDeleted = session.byNaturalId(AnnotatedEntity.class).using("title", "dummy:1").getReference();
+        session.delete(toBeDeleted);
+
+        AnnotatedEntity toBeDeleted2 = session.byNaturalId(AnnotatedEntity.class).using("title", "dummy:0").getReference();
+        session.delete(toBeDeleted2);
+        tx.commit();
+        session.close();
+
+        assertTopicNotifications(4, CACHE_ANNOTATED_ENTITY + "##NaturalId");
+        assertTopicNotifications(4, getTimestampsRegionName());
+    }
+
+    @Test
+    public void testDeleteOneEntity() throws Exception {
+        insertDummyEntities(1, 1);
+
+        deleteDummyEntity(0);
+
+        assertTopicNotifications(1, CACHE_ENTITY);
+        assertTopicNotifications(1, CACHE_ENTITY_PROPERTIES);
+        assertTopicNotifications(1, CACHE_PROPERTY);
+        assertTopicNotifications(9, getTimestampsRegionName());
+    }
+
+    @Test
+    public void testDeleteEntities() throws Exception {
+        insertDummyEntities(10, 4);
+
+        for (int i = 0; i < 3; i++) {
+            deleteDummyEntity(i);
+        }
+
+        assertTopicNotifications(3, CACHE_ENTITY);
+        assertTopicNotifications(3, CACHE_ENTITY_PROPERTIES);
+        assertTopicNotifications(12, CACHE_PROPERTY);
+        assertTopicNotifications(67, getTimestampsRegionName());
+    }
+
+    @Test
+    public void testUpdateOneEntity() {
+        insertDummyEntities(10, 4);
+
+        getDummyEntities(10);
+
+        updateDummyEntityName(2, "updated");
+
+        assertTopicNotifications(1, CACHE_ENTITY);
+        assertTopicNotifications(0, CACHE_ENTITY_PROPERTIES);
+        assertTopicNotifications(0, CACHE_PROPERTY);
+        assertTopicNotifications(54, getTimestampsRegionName());
+    }
+
+    @Test
+    public void testUpdateEntities() {
+        insertDummyEntities(1, 10);
+
+        executeUpdateQuery("update DummyEntity set name = 'updated-name' where id < 2");
+
+        assertTopicNotifications(1, CACHE_ENTITY);
+        assertTopicNotifications(0, CACHE_ENTITY_PROPERTIES);
+        assertTopicNotifications(0, CACHE_PROPERTY);
+        assertTopicNotifications(15, getTimestampsRegionName());
+    }
+
+    @Override
+    protected AccessType getCacheStrategy() {
+        return AccessType.READ_WRITE;
+    }
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/VersionAwareMapMergePolicyTest.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/VersionAwareMapMergePolicyTest.java
@@ -1,0 +1,98 @@
+package com.hazelcast.hibernate;
+
+
+import com.hazelcast.spi.merge.MergingValue;
+import com.hazelcast.spi.merge.SplitBrainMergePolicy;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.hibernate.cache.spi.entry.CacheEntry;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class VersionAwareMapMergePolicyTest {
+
+
+    private static final MockVersion versionOld = new MockVersion(0);
+    private static final MockVersion versionNew = new MockVersion(1);
+
+    protected SplitBrainMergePolicy policy;
+
+    @Before
+    public void given() {
+        policy = new VersionAwareMapMergePolicy();
+    }
+
+    @Test
+    public void merge_mergingUptodate() {
+        CacheEntry existing = cacheEntryWithVersion(versionOld);
+        CacheEntry merging = cacheEntryWithVersion(versionNew);
+
+        MergingValue entryExisting = entryWithGivenValue(existing);
+        MergingValue entryMerging = entryWithGivenValue(merging);
+
+        assertEquals(merging, policy.merge(entryMerging, entryExisting));
+    }
+
+    @Test
+    public void merge_mergingStale() {
+        CacheEntry existing = cacheEntryWithVersion(versionNew);
+        CacheEntry merging = cacheEntryWithVersion(versionOld);
+
+        MergingValue entryExisting = entryWithGivenValue(existing);
+        MergingValue entryMerging = entryWithGivenValue(merging);
+
+        assertEquals(existing, policy.merge(entryMerging, entryExisting));
+    }
+
+    @Test
+    public void merge_mergingNull() {
+        CacheEntry existing = null;
+        CacheEntry merging = cacheEntryWithVersion(versionNew);
+
+        MergingValue entryExisting = entryWithGivenValue(existing);
+        MergingValue entryMerging = entryWithGivenValue(merging);
+
+        assertEquals(merging, policy.merge(entryMerging, entryExisting));
+    }
+
+
+    private CacheEntry cacheEntryWithVersion(MockVersion mockVersion) {
+        CacheEntry cacheEntry = mock(CacheEntry.class);
+        when(cacheEntry.getVersion()).thenReturn(mockVersion);
+        return cacheEntry;
+    }
+
+    private MergingValue entryWithGivenValue(Object value) {
+        MergingValue mergingValue= mock(MergingValue.class);
+        try {
+            when(mergingValue.getValue()).thenReturn(value);
+            return mergingValue;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    protected static class MockVersion implements Comparable<MockVersion> {
+
+        private int version;
+
+        public MockVersion(int version) {
+            this.version = version;
+        }
+
+        @Override
+        public int compareTo(MockVersion o) {
+            return version - o.version;
+        }
+    }
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/access/ReadWriteAccessDelegateTest.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/access/ReadWriteAccessDelegateTest.java
@@ -1,0 +1,54 @@
+package com.hazelcast.hibernate.access;
+
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.hibernate.HibernateTestSupport;
+import com.hazelcast.hibernate.RegionCache;
+import com.hazelcast.hibernate.region.HazelcastRegion;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.hibernate.cache.spi.access.SoftLock;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class ReadWriteAccessDelegateTest extends HibernateTestSupport {
+
+    private RegionCache cache;
+    private ReadWriteAccessDelegate<HazelcastRegion> delegate;
+
+
+    @Before
+    public void setUp() {
+        ILogger log = Logger.getLogger(ReadWriteAccessDelegateTest.class);
+
+        cache = mock(RegionCache.class);
+
+        HazelcastRegion region = mock(HazelcastRegion.class);
+        when(region.getLogger()).thenReturn(log);
+        when(region.getCache()).thenReturn(cache);
+
+        delegate = new ReadWriteAccessDelegate<HazelcastRegion>(region, null);
+    }
+
+    @Test
+    public void testAfterInsert() {
+        when(cache.insert(any(), any(), any())).thenThrow(new HazelcastException("expected exception"));
+        assertFalse(delegate.afterInsert(null, null, null));
+    }
+
+    @Test
+    public void testAfterUpdate() {
+        when(cache.update(any(), any(), any(), any(SoftLock.class))).thenThrow(new HazelcastException("expected exception"));
+        assertFalse(delegate.afterUpdate(null, null, null, null, null));
+    }
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/distributed/LockEntryProcessorTest.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/distributed/LockEntryProcessorTest.java
@@ -1,0 +1,69 @@
+package com.hazelcast.hibernate.distributed;
+
+import com.hazelcast.hibernate.serialization.Expirable;
+import com.hazelcast.hibernate.serialization.ExpiryMarker;
+import com.hazelcast.hibernate.serialization.Value;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.matches;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class LockEntryProcessorTest {
+
+    @Test
+    public void testProcessWithNullEntry() throws Exception {
+        Map.Entry<Object, Expirable> entry = mockEntry(null);
+        LockEntryProcessor processor = new LockEntryProcessor("next-marker-id", 100L, null);
+        ArgumentCaptor<Expirable> captor = ArgumentCaptor.forClass(Expirable.class);
+        processor.process(entry);
+        verify(entry).setValue(captor.capture());
+        Expirable result = captor.getValue();
+        assertThat(result, instanceOf(ExpiryMarker.class));
+        ExpiryMarker marker = (ExpiryMarker) result;
+        assertTrue(marker.matches(new ExpiryMarker(null, 0L, "next-marker-id")));
+    }
+
+    @Test
+    public void testProcessWithValueEntry() throws Exception {
+        Map.Entry<Object, Expirable> entry = mockEntry(new Value(null, 500L, "blah"));
+        LockEntryProcessor processor = new LockEntryProcessor("next-marker-id", 100L, null);
+        ArgumentCaptor<Expirable> captor = ArgumentCaptor.forClass(Expirable.class);
+        processor.process(entry);
+        verify(entry).setValue(captor.capture());
+        Expirable result = captor.getValue();
+        assertThat(result, instanceOf(ExpiryMarker.class));
+        ExpiryMarker marker = (ExpiryMarker) result;
+        assertTrue(marker.matches(new ExpiryMarker(null, 0L, "next-marker-id")));
+    }
+
+    @Test
+    public void testProcessWithMarkerEntry() throws Exception {
+        ExpiryMarker original = new ExpiryMarker(null, 0L, "the-marker-id");
+        Map.Entry<Object, Expirable> entry = mockEntry(original);
+        LockEntryProcessor processor = new LockEntryProcessor("next-marker-id", 100L, null);
+        ArgumentCaptor<Expirable> captor = ArgumentCaptor.forClass(Expirable.class);
+        processor.process(entry);
+        verify(entry).setValue(captor.capture());
+        Expirable result = captor.getValue();
+        assertThat(result, instanceOf(ExpiryMarker.class));
+        ExpiryMarker marker = (ExpiryMarker) result;
+        assertFalse(marker.matches(new ExpiryMarker(null, 0L, "next-marker-id")));
+        assertTrue(marker.matches(original));
+        assertTrue(marker.isConcurrent());
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map.Entry<Object, Expirable> mockEntry(Expirable value) {
+        Map.Entry entry = mock(Map.Entry.class);
+        when(entry.getValue()).thenReturn(value);
+        return entry;
+    }
+
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/distributed/UnlockEntryProcessorTest.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/distributed/UnlockEntryProcessorTest.java
@@ -1,0 +1,69 @@
+package com.hazelcast.hibernate.distributed;
+
+import com.hazelcast.hibernate.serialization.Expirable;
+import com.hazelcast.hibernate.serialization.ExpiryMarker;
+import com.hazelcast.hibernate.serialization.Value;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class UnlockEntryProcessorTest {
+
+    @Test
+    public void testProcessWithNullEntry() throws Exception {
+        Map.Entry<Object, Expirable> entry = mockEntry(null);
+        UnlockEntryProcessor processor = new UnlockEntryProcessor(new ExpiryMarker(null, 100L, "other-marker-id"), "next-marker-id", 100L);
+        processor.process(entry);
+        verify(entry, never()).setValue(any(Expirable.class));
+    }
+
+    @Test
+    public void testProcessWithDifferentMarker() throws Exception {
+        Map.Entry<Object, Expirable> entry = mockEntry(new ExpiryMarker(null, 100L, "the-marker-id"));
+        UnlockEntryProcessor processor = new UnlockEntryProcessor(new ExpiryMarker(null, 100L, "other-marker-id"), "next-marker-id", 100L);
+        processor.process(entry);
+        verify(entry, never()).setValue(any(Expirable.class));
+    }
+
+    @Test
+    public void testProcessWithValue() throws Exception {
+        Map.Entry<Object, Expirable> entry = mockEntry(new Value(null, 100L, "some-value"));
+        UnlockEntryProcessor processor = new UnlockEntryProcessor(new ExpiryMarker(null, 100L, "other-marker-id"), "next-marker-id", 150L);
+        ArgumentCaptor<Expirable> captor = ArgumentCaptor.forClass(Expirable.class);
+        processor.process(entry);
+        verify(entry).setValue(captor.capture());
+        Expirable result = captor.getValue();
+        assertThat(result, instanceOf(ExpiryMarker.class));
+        ExpiryMarker marker = (ExpiryMarker) result;
+        assertFalse("market must be expirable after timestamp", marker.isReplaceableBy(150L, null, null));
+        assertTrue("market must be expirable after timestamp", marker.isReplaceableBy(151L, null, null));
+    }
+
+    @Test
+    public void testProcessMatchingLock() throws Exception {
+        ExpiryMarker original = new ExpiryMarker(null, 100L, "the-marker-id").markForExpiration(100L, "some-marker-id");
+        Map.Entry<Object, Expirable> entry = mockEntry(original);
+        UnlockEntryProcessor processor = new UnlockEntryProcessor(new ExpiryMarker(null, 100L, "the-marker-id"), "next-marker-id", 150L);
+        ArgumentCaptor<Expirable> captor = ArgumentCaptor.forClass(Expirable.class);
+        processor.process(entry);
+        verify(entry).setValue(captor.capture());
+        Expirable result = captor.getValue();
+        assertNotSame(original, result);
+        assertThat(result, instanceOf(ExpiryMarker.class));
+        ExpiryMarker marker = (ExpiryMarker) result;
+        assertTrue(marker.matches(original));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map.Entry<Object, Expirable> mockEntry(Expirable value) {
+        Map.Entry entry = mock(Map.Entry.class);
+        when(entry.getValue()).thenReturn(value);
+        return entry;
+    }
+
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/distributed/UpdateEntryProcessorTest.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/distributed/UpdateEntryProcessorTest.java
@@ -1,0 +1,79 @@
+package com.hazelcast.hibernate.distributed;
+
+import com.hazelcast.hibernate.serialization.Expirable;
+import com.hazelcast.hibernate.serialization.ExpiryMarker;
+import com.hazelcast.hibernate.serialization.Value;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class UpdateEntryProcessorTest {
+
+    @Test
+    public void testProcessWithNullEntry() throws Exception {
+        Map.Entry<Object, Expirable> entry = mockEntry(null);
+        UpdateEntryProcessor processor = new UpdateEntryProcessor(new ExpiryMarker(null, 100L, "the-marker-id"), "new-value", null, "next-marker-id", 150L);
+        ArgumentCaptor<Expirable> captor = ArgumentCaptor.forClass(Expirable.class);
+        assertTrue(processor.process(entry));
+        verify(entry).setValue(captor.capture());
+        Expirable result = captor.getValue();
+        assertThat(result, instanceOf(Value.class));
+        assertEquals("new-value", result.getValue());
+    }
+
+    @Test
+    public void testProcessWithMatchingMarker() throws Exception {
+        Map.Entry<Object, Expirable> entry = mockEntry(new ExpiryMarker(null, 100L, "the-marker-id"));
+        UpdateEntryProcessor processor = new UpdateEntryProcessor(new ExpiryMarker(null, 100L, "the-marker-id"), "new-value", null, "next-marker-id", 150L);
+        ArgumentCaptor<Expirable> captor = ArgumentCaptor.forClass(Expirable.class);
+        assertTrue(processor.process(entry));
+        verify(entry).setValue(captor.capture());
+        Expirable result = captor.getValue();
+        assertThat(result, instanceOf(Value.class));
+        assertEquals("new-value", result.getValue());
+    }
+
+    @Test
+    public void testProcessWithMatchingConcurrentMarker() throws Exception {
+        Map.Entry<Object, Expirable> entry = mockEntry(new ExpiryMarker(null, 100L, "the-marker-id").markForExpiration(100L, "ignored"));
+        UpdateEntryProcessor processor = new UpdateEntryProcessor(new ExpiryMarker(null, 100L, "the-marker-id"), "new-value", null, "next-marker-id", 150L);
+        ArgumentCaptor<Expirable> captor = ArgumentCaptor.forClass(Expirable.class);
+        assertFalse(processor.process(entry));
+        verify(entry).setValue(captor.capture());
+        Expirable result = captor.getValue();
+        assertThat(result, instanceOf(ExpiryMarker.class));
+    }
+
+    @Test
+    public void testProcessWithDifferentMarker() throws Exception {
+        Map.Entry<Object, Expirable> entry = mockEntry(new ExpiryMarker(null, 100L, "other-marker-id"));
+        UpdateEntryProcessor processor = new UpdateEntryProcessor(new ExpiryMarker(null, 100L, "the-marker-id"), "new-value", null, "next-marker-id", 150L);
+        assertFalse(processor.process(entry));
+        verify(entry, never()).setValue(any(Expirable.class));
+    }
+
+    @Test
+    public void testProcessWithValue() throws Exception {
+        Map.Entry<Object, Expirable> entry = mockEntry(new Value(null, 100L, "some-value"));
+        UpdateEntryProcessor processor = new UpdateEntryProcessor(new ExpiryMarker(null, 100L, "the-marker-id"), "new-value", null, "next-marker-id", 150L);
+        ArgumentCaptor<Expirable> captor = ArgumentCaptor.forClass(Expirable.class);
+        assertFalse(processor.process(entry));
+        verify(entry).setValue(captor.capture());
+        Expirable result = captor.getValue();
+        assertThat(result, instanceOf(ExpiryMarker.class));
+        assertTrue("Marker should be expired", result.isReplaceableBy(151L, null, null));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map.Entry<Object, Expirable> mockEntry(Expirable value) {
+        Map.Entry entry = mock(Map.Entry.class);
+        when(entry.getValue()).thenReturn(value);
+        return entry;
+    }
+
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/entity/AnnotatedEntity.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/entity/AnnotatedEntity.java
@@ -1,0 +1,46 @@
+package com.hazelcast.hibernate.entity;
+
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.NaturalId;
+import org.hibernate.annotations.NaturalIdCache;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@NaturalIdCache
+@Entity
+@Table( name = "ANNOTATED_ENTITIES" )
+public class AnnotatedEntity {
+    private Long id;
+
+    private String title;
+
+    public AnnotatedEntity() {
+    }
+
+    public AnnotatedEntity(String title) {
+        this.title = title;
+    }
+
+    @NaturalId(mutable = true)
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    @Id
+    @GeneratedValue(generator="increment")
+    @GenericGenerator(name="increment", strategy = "increment")
+    public Long getId() {
+        return id;
+    }
+
+    private void setId(Long id) {
+        this.id = id;
+    }
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/entity/DummyEntity.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/entity/DummyEntity.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.entity;
+
+import java.util.Date;
+import java.util.Set;
+
+public class DummyEntity {
+
+    private long id;
+
+    private int version;
+
+    private String name;
+
+    private double value;
+
+    private Date date;
+
+    private Set<DummyProperty> properties;
+
+    public DummyEntity() {
+        super();
+    }
+
+    public DummyEntity(long id, String name, double value, Date date) {
+        super();
+        this.id = id;
+        this.name = name;
+        this.value = value;
+        this.date = date;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public double getValue() {
+        return value;
+    }
+
+    public void setValue(double value) {
+        this.value = value;
+    }
+
+    public Date getDate() {
+        return date;
+    }
+
+    public void setDate(Date date) {
+        this.date = date;
+    }
+
+    public void setProperties(Set<DummyProperty> properties) {
+        this.properties = properties;
+    }
+
+    public Set<DummyProperty> getProperties() {
+        return properties;
+    }
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/entity/DummyProperty.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/entity/DummyProperty.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.entity;
+
+public class DummyProperty {
+
+    private long id;
+
+    private int version;
+
+    private String key;
+
+    private DummyEntity entity;
+
+    public DummyProperty() {
+    }
+
+    public DummyProperty(String key) {
+        super();
+        this.key = key;
+    }
+
+    public DummyProperty(String key, DummyEntity entity) {
+        super();
+        this.key = key;
+        this.entity = entity;
+    }
+
+    public DummyProperty(long id, String key, DummyEntity entity) {
+        super();
+        this.id = id;
+        this.key = key;
+        this.entity = entity;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public DummyEntity getEntity() {
+        return entity;
+    }
+
+    public void setEntity(DummyEntity entity) {
+        this.entity = entity;
+    }
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/instance/HazelcastMockInstanceFactory.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/instance/HazelcastMockInstanceFactory.java
@@ -1,0 +1,21 @@
+package com.hazelcast.hibernate.instance;
+
+import org.hibernate.cache.CacheException;
+
+import java.util.Properties;
+
+public class HazelcastMockInstanceFactory implements IHazelcastInstanceFactory
+{
+	private static ThreadLocal<IHazelcastInstanceLoader> loaders = new ThreadLocal<IHazelcastInstanceLoader>();
+
+	public static void setThreadLocalLoader(IHazelcastInstanceLoader loader)
+	{
+		loaders.set(loader);
+	}
+
+	@Override
+	public IHazelcastInstanceLoader createInstanceLoader(Properties props) throws CacheException
+	{
+		return loaders.get();
+	}
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/instance/HazelcastMockInstanceLoader.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/instance/HazelcastMockInstanceLoader.java
@@ -1,0 +1,179 @@
+package com.hazelcast.hibernate.instance;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.ClientNetworkConfig;
+import com.hazelcast.client.config.ConnectionRetryConfig;
+import com.hazelcast.client.config.XmlClientConfigBuilder;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.internal.config.ConfigLoader;
+import com.hazelcast.config.InvalidConfigurationException;
+import com.hazelcast.config.XmlConfigBuilder;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.CacheEnvironment;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import org.hibernate.cache.CacheException;
+import org.hibernate.internal.util.config.ConfigurationHelper;
+
+import java.io.IOException;
+import java.util.Properties;
+
+public class HazelcastMockInstanceLoader implements IHazelcastInstanceLoader {
+
+    private static final ILogger LOGGER = Logger.getLogger(HazelcastMockInstanceLoader.class);
+    private static final int INITIAL_BACKOFF_MS = 2000;
+    private static final int MAX_BACKOFF_MS = 35000;
+    private static final double BACKOFF_MULTIPLIER = 1.5D;
+
+    private final Properties props = new Properties();
+    private String instanceName;
+    private HazelcastInstance instance;
+    private Config config;
+    private HazelcastInstance client;
+    private TestHazelcastFactory factory;
+    public void configure(Properties props) {
+        this.props.putAll(props);
+    }
+
+    public HazelcastInstance loadInstance() throws CacheException {
+        if (CacheEnvironment.isNativeClient(props)) {
+            if (client != null && client.getLifecycleService().isRunning()) {
+                LOGGER.warning("Current HazelcastClient is already active! Shutting it down...");
+                unloadInstance();
+            }
+            String address = ConfigurationHelper.getString(CacheEnvironment.NATIVE_CLIENT_ADDRESS, props, null);
+            String clientClusterName = ConfigurationHelper.getString(CacheEnvironment.NATIVE_CLIENT_CLUSTER_NAME, props, null);
+            String configResourcePath = CacheEnvironment.getConfigFilePath(props);
+
+            ClientConfig clientConfig = buildClientConfig(configResourcePath);
+            if (clientClusterName != null) {
+                clientConfig.setClusterName(clientClusterName);
+            }
+            if (address != null) {
+                clientConfig.getNetworkConfig().addAddress(address);
+            }
+            clientConfig.getNetworkConfig().setSmartRouting(true);
+            clientConfig.getNetworkConfig().setRedoOperation(true);
+            client = factory.newHazelcastClient(clientConfig);
+            return client;
+        } else {
+            if (instance != null && instance.getLifecycleService().isRunning()) {
+                LOGGER.warning("Current HazelcastInstance is already loaded and running! "
+                        + "Returning current instance...");
+                return instance;
+            }
+            String configResourcePath = null;
+            instanceName = CacheEnvironment.getInstanceName(props);
+            configResourcePath = CacheEnvironment.getConfigFilePath(props);
+            if (!isEmpty(configResourcePath)) {
+                try {
+                    config = ConfigLoader.load(configResourcePath);
+                } catch (IOException e) {
+                    LOGGER.warning("IOException: " + e.getMessage());
+                }
+                if (config == null) {
+                    throw new CacheException("Could not find configuration file: "
+                            + configResourcePath);
+                }
+            }
+            if (instanceName != null) {
+                instance = getHazelcastInstanceByName(instanceName);
+                if (instance == null) {
+                    try {
+                        createOrGetInstance();
+                    } catch (InvalidConfigurationException ignored) {
+                        instance = getHazelcastInstanceByName(instanceName);
+                    }
+                }
+            } else {
+                createOrGetInstance();
+            }
+            return instance;
+        }
+    }
+
+    private void createOrGetInstance() throws InvalidConfigurationException {
+        if (config == null) {
+            config = new XmlConfigBuilder().build();
+        }
+        config.setInstanceName(instanceName);
+        instance = factory.newHazelcastInstance(config);
+    }
+
+    public void unloadInstance() throws CacheException {
+        if (CacheEnvironment.isNativeClient(props)) {
+            if (client == null) {
+                return;
+            }
+            try {
+                client.getLifecycleService().shutdown();
+                client = null;
+            } catch (Exception e) {
+                throw new CacheException(e);
+            }
+        } else {
+            if (instance == null) {
+                return;
+            }
+            final boolean shutDown = CacheEnvironment.shutdownOnStop(props, (instanceName == null));
+            if (!shutDown) {
+                LOGGER.warning(CacheEnvironment.SHUTDOWN_ON_STOP + " property is set to 'false'. "
+                        + "Leaving current HazelcastInstance active! (Warning: Do not disable Hazelcast "
+                        + CacheEnvironment.HAZELCAST_SHUTDOWN_HOOK_ENABLED + " property!)");
+                return;
+            }
+            try {
+                instance.getLifecycleService().shutdown();
+                instance = null;
+                factory.shutdownAll();
+            } catch (Exception e) {
+                throw new CacheException(e);
+            }
+        }
+    }
+
+    public TestHazelcastFactory getInstanceFactory() throws CacheException {
+        return factory;
+    }
+
+    public void setInstanceFactory(TestHazelcastFactory factory) {
+        this.factory = factory;
+    }
+
+    private static boolean isEmpty(String s) {
+        return s == null || s.trim().length() == 0;
+    }
+
+    private HazelcastInstance getHazelcastInstanceByName(String instanceName) {
+        HazelcastInstance foundInstance = null;
+        for (HazelcastInstance instance : factory.getAllHazelcastInstances()) {
+            if(instanceName.equals(instance.getName())) {
+                foundInstance = instance;
+            }
+        }
+        return foundInstance;
+    }
+
+    private ClientConfig buildClientConfig(String configResourcePath) {
+        ClientConfig clientConfig = null;
+        if (configResourcePath != null) {
+            try {
+                clientConfig = new XmlClientConfigBuilder(configResourcePath).build();
+            } catch (IOException e) {
+                LOGGER.warning("Could not load client configuration: " + configResourcePath, e);
+            }
+        }
+        if (clientConfig == null) {
+            clientConfig = new ClientConfig();
+            final ClientNetworkConfig networkConfig = clientConfig.getNetworkConfig();
+            final ConnectionRetryConfig connectionRetryConfig = clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig();
+            networkConfig.setSmartRouting(true);
+            networkConfig.setRedoOperation(true);
+            connectionRetryConfig.setInitialBackoffMillis(INITIAL_BACKOFF_MS);
+            connectionRetryConfig.setMaxBackoffMillis(MAX_BACKOFF_MS);
+            connectionRetryConfig.setMultiplier(BACKOFF_MULTIPLIER);
+        }
+        return clientConfig;
+    }
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/local/LocalRegionCacheTest.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/local/LocalRegionCacheTest.java
@@ -1,0 +1,100 @@
+package com.hazelcast.hibernate.local;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.topic.ITopic;
+import com.hazelcast.topic.MessageListener;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.hibernate.cache.spi.CacheDataDescription;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Comparator;
+import java.util.UUID;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+@SuppressWarnings("unchecked")
+public class LocalRegionCacheTest {
+
+    private static final String CACHE_NAME = "cache";
+
+    @Test
+    public void testConstructorIgnoresUnsupportedOperationExceptionsFromConfig() {
+        HazelcastInstance instance = mock(HazelcastInstance.class);
+        doThrow(UnsupportedOperationException.class).when(instance).getConfig();
+
+        new LocalRegionCache(CACHE_NAME, instance, null, false);
+    }
+
+    @Test
+    public void testConstructorIgnoresVersionComparatorForUnversionedData() {
+        CacheDataDescription description = mock(CacheDataDescription.class);
+        doThrow(AssertionError.class).when(description).getVersionComparator(); // Will fail the test if called
+
+        new LocalRegionCache(CACHE_NAME, null, description);
+        verify(description).isVersioned(); // Verify that the versioned flag was checked
+        verifyNoMoreInteractions(description);
+    }
+
+    @Test
+    public void testConstructorSetsVersionComparatorForVersionedData() {
+        Comparator<?> comparator = mock(Comparator.class);
+
+        CacheDataDescription description = mock(CacheDataDescription.class);
+        when(description.getVersionComparator()).thenReturn(comparator);
+        when(description.isVersioned()).thenReturn(true);
+
+        new LocalRegionCache(CACHE_NAME, null, description);
+        verify(description).getVersionComparator();
+        verify(description).isVersioned();
+    }
+
+    @Test
+    public void testFourArgConstructorDoesNotRegisterTopicListenerIfNotRequested() {
+        MapConfig mapConfig = mock(MapConfig.class);
+
+        Config config = mock(Config.class);
+        when(config.findMapConfig(eq(CACHE_NAME))).thenReturn(mapConfig);
+
+        HazelcastInstance instance = mock(HazelcastInstance.class);
+        when(instance.getConfig()).thenReturn(config);
+
+        new LocalRegionCache(CACHE_NAME, instance, null, false);
+        verify(config).findMapConfig(eq(CACHE_NAME));
+        verify(instance).getConfig();
+        verify(instance, never()).getTopic(anyString());
+    }
+
+    // Verifies that the three-argument constructor still registers a listener with a topic if the HazelcastInstance
+    // is provided. This ensures the old behavior has not been regressed by adding the new four argument constructor
+    @Test
+    public void testThreeArgConstructorRegistersTopicListener() {
+        MapConfig mapConfig = mock(MapConfig.class);
+
+        Config config = mock(Config.class);
+        when(config.findMapConfig(eq(CACHE_NAME))).thenReturn(mapConfig);
+
+        ITopic<Object> topic = mock(ITopic.class);
+        when(topic.addMessageListener(isNotNull(MessageListener.class))).thenReturn(UUID.randomUUID());
+
+        HazelcastInstance instance = mock(HazelcastInstance.class);
+        when(instance.getConfig()).thenReturn(config);
+        when(instance.getTopic(eq(CACHE_NAME))).thenReturn(topic);
+
+        new LocalRegionCache(CACHE_NAME, instance, null);
+        verify(config).findMapConfig(eq(CACHE_NAME));
+        verify(instance).getConfig();
+        verify(instance).getTopic(eq(CACHE_NAME));
+        verify(topic).addMessageListener(isNotNull(MessageListener.class));
+    }
+
+    public static void runCleanup(LocalRegionCache cache) {
+        cache.cleanup();
+    }
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/local/TimestampsRegionCacheTest.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/local/TimestampsRegionCacheTest.java
@@ -1,0 +1,93 @@
+package com.hazelcast.hibernate.local;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.cluster.Cluster;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.topic.ITopic;
+import com.hazelcast.cluster.Member;
+import com.hazelcast.topic.Message;
+import com.hazelcast.topic.MessageListener;
+
+import java.util.UUID;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TimestampsRegionCacheTest {
+
+    private static final String CACHE_NAME = "cache";
+
+    @Mock private Config config;
+    @Mock private MapConfig mapConfig;
+    @Mock private ITopic<Object> topic;
+    @Mock private HazelcastInstance instance;
+    @Mock private Cluster cluster;
+    @Mock private Member member;
+
+    private TimestampsRegionCache target;
+    private MessageListener<Object> listener;
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Before
+    public void setup() {
+        when(config.findMapConfig(eq(CACHE_NAME))).thenReturn(mapConfig);
+        when(instance.getCluster()).thenReturn(cluster);
+        when(instance.getConfig()).thenReturn(config);
+        when(instance.getTopic(eq(CACHE_NAME))).thenReturn(topic);
+
+        // make the message appear that it is coming from a different member of the cluster
+        when(member.localMember()).thenReturn(false);
+
+        ArgumentCaptor<MessageListener> listener = ArgumentCaptor.forClass(MessageListener.class);
+        when(topic.addMessageListener(listener.capture())).thenReturn(UUID.randomUUID());
+        target = new TimestampsRegionCache(CACHE_NAME, instance);
+        this.listener = listener.getValue();
+    }
+
+    @Test
+    public void shouldUseClusterTimestampFromInvalidationmessageInsteadOfSystemTime() {
+        long firstTimestamp = 1;
+        long secondTimestamp = 2;
+        long publishTime = 3;
+        long clusterTime = 4;
+
+        when(cluster.getClusterTime()).thenReturn(firstTimestamp, secondTimestamp);
+
+        // cache is primed by call, that uses clusterTime instead of system clock for timestamp
+        assertThat(target.put("QuerySpace", firstTimestamp, firstTimestamp, null), is(true));
+
+        assertThat("primed value should be in the cache", (Long)target.get("QuerySpace", firstTimestamp), is(firstTimestamp));
+
+        // a message is generated on a different cluster member informing us to update the timestamp region cache
+        Message<Object> message = new Message<Object>("topicName", new Timestamp("QuerySpace", secondTimestamp), publishTime, member);
+
+        // process the timestamp region update
+        listener.onMessage(message);
+
+        // this fails if we use system time instead of cluster time, causing the value to stay invisible until clustertime == system time (which it often isn't)
+        assertThat("key should be visible and have value specified in timestamp message, with current cluster time.", (Long)target.get("QuerySpace", clusterTime), is(secondTimestamp));
+    }
+
+    @Test
+    public void clearCache() {
+        long aTimestamp = 1;
+        assertThat(target.put("QuerySpace", aTimestamp, aTimestamp, null), is(true));
+        assertThat("value should be in the cache", (Long)target.get("QuerySpace", aTimestamp), is(aTimestamp));
+
+        target.clear();
+
+        assertThat("value should not be in the cache", target.get("QuerySpace", aTimestamp), nullValue());
+    }    
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/region/HazelcastQueryResultsRegionTest.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/region/HazelcastQueryResultsRegionTest.java
@@ -1,0 +1,136 @@
+package com.hazelcast.hibernate.region;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.EvictionConfig;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.cluster.Cluster;
+import com.hazelcast.config.MaxSizePolicy;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.local.LocalRegionCache;
+import com.hazelcast.hibernate.local.LocalRegionCacheTest;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class HazelcastQueryResultsRegionTest {
+
+    private static final String REGION_NAME = "query.test";
+
+    private int maxSize = 50;
+    private int timeout = 60;
+
+    private MapConfig mapConfig;
+    private Config config;
+
+    private HazelcastInstance instance;
+    private HazelcastQueryResultsRegion region;
+
+    @Before
+    public void setUp() throws Exception {
+        mapConfig = mock(MapConfig.class);
+        EvictionConfig evictionConfig = new EvictionConfig();
+        evictionConfig.setMaxSizePolicy(MaxSizePolicy.PER_NODE);
+        evictionConfig.setSize(maxSize);
+        when(mapConfig.getEvictionConfig()).thenReturn(evictionConfig);
+
+        when(mapConfig.getTimeToLiveSeconds()).thenReturn(timeout);
+
+        config = mock(Config.class);
+        when(config.findMapConfig(eq(REGION_NAME))).thenReturn(mapConfig);
+
+        Cluster cluster = mock(Cluster.class);
+        when(cluster.getClusterTime()).thenAnswer(new Answer<Long>() {
+            @Override
+            public Long answer(InvocationOnMock invocation) throws Throwable {
+                return System.currentTimeMillis();
+            }
+        });
+
+        instance = mock(HazelcastInstance.class);
+        when(instance.getConfig()).thenReturn(config);
+        when(instance.getCluster()).thenReturn(cluster);
+
+        region = new HazelcastQueryResultsRegion(instance, REGION_NAME, new Properties());
+    }
+
+    /**
+     * Verifies that the region retrieved the MapConfig and set its timeout from the TTL.
+     * Also verifies that the nested LocalRegionCache retrieved the configuration,
+     * but did not register a listener on any ITopic.
+     */
+    @Test
+    public void testCacheHonorsConfiguration() {
+        assertEquals(TimeUnit.SECONDS.toMillis(timeout), region.getTimeout());
+        verify(instance, atLeastOnce()).getConfig();
+        // ensure a topic is not requested
+        verify(instance, never()).getTopic(anyString());
+        verify(config, atLeastOnce()).findMapConfig(eq(REGION_NAME));
+        // should have been retrieved by the region itself
+        verify(mapConfig, times(2)).getTimeToLiveSeconds();
+
+        // load the cache with more entries than the configured max size
+        LocalRegionCache regionCache = region.getCache();
+        assertNotNull(regionCache);
+
+        int overSized = maxSize * 2;
+        for (int i = 0; i < overSized; ++i) {
+            regionCache.put(i, i, System.currentTimeMillis(), i);
+        }
+        assertEquals(overSized, regionCache.size());
+
+        // run cleanup to apply the configured limits (the TTL is not tested here for simplicity and speed of this test)
+        LocalRegionCacheTest.runCleanup(regionCache);
+        // the default size is 100,000, so if the configuration is ignored no elements will be removed.
+        // But if the configuration is applied as expected
+        assertTrue(regionCache.size() <= 50);
+        verify(mapConfig).getEvictionConfig();
+        assertEquals(maxSize, mapConfig.getEvictionConfig().getSize());
+        assertEquals(MaxSizePolicy.PER_NODE, mapConfig.getEvictionConfig().getMaxSizePolicy());
+        verify(mapConfig, times(3)).getTimeToLiveSeconds(); // Should have been retrieved a second time by the cache
+    }
+
+    @Test
+    public void testEvict() {
+        region.evict("evictionKey");
+    }
+
+    @Test
+    public void testEvictAll() {
+        region.evictAll();
+    }
+
+    @Test
+    public void testGet() {
+        assertNull(region.get(null, "getKey"));
+    }
+
+    @Test
+    public void testPut() {
+        region.put(null, "putKey", "putValue");
+        assertEquals("putValue", region.get(null, "putKey"));
+    }
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/region/HazelcastTimestampsRegionTest.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/region/HazelcastTimestampsRegionTest.java
@@ -1,0 +1,146 @@
+package com.hazelcast.hibernate.region;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.EvictionConfig;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.cluster.Cluster;
+import com.hazelcast.config.MaxSizePolicy;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.OperationTimeoutException;
+import com.hazelcast.hibernate.RegionCache;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class HazelcastTimestampsRegionTest {
+
+    private static final String REGION_NAME = "query.test";
+
+    private int timeout = 60;
+
+    private MapConfig mapConfig;
+    private Config config;
+
+    private HazelcastInstance instance;
+    private RegionCache cache;
+    private HazelcastTimestampsRegion<RegionCache> region;
+
+    @Before
+    public void setUp() throws Exception {
+        mapConfig = mock(MapConfig.class);
+        EvictionConfig evictionConfig = new EvictionConfig();
+        evictionConfig.setMaxSizePolicy(MaxSizePolicy.PER_NODE);
+        evictionConfig.setSize(50);
+        when(mapConfig.getEvictionConfig()).thenReturn(evictionConfig);
+
+        when(mapConfig.getTimeToLiveSeconds()).thenReturn(timeout);
+
+        config = mock(Config.class);
+        when(config.findMapConfig(eq(REGION_NAME))).thenReturn(mapConfig);
+
+        Cluster cluster = mock(Cluster.class);
+        when(cluster.getClusterTime()).thenAnswer(new Answer<Long>() {
+            @Override
+            public Long answer(InvocationOnMock invocation) throws Throwable {
+                return System.currentTimeMillis();
+            }
+        });
+
+        instance = mock(HazelcastInstance.class);
+        when(instance.getConfig()).thenReturn(config);
+        when(instance.getCluster()).thenReturn(cluster);
+
+        cache = mock(RegionCache.class);
+
+        region = new HazelcastTimestampsRegion<RegionCache>(instance, REGION_NAME, new Properties(), cache);
+    }
+
+    /**
+     * Verifies that the region retrieved the MapConfig and set its timeout from the TTL.
+     * Also verifies that the nested LocalRegionCache retrieved the configuration,
+     * but did not register a listener on any ITopic.
+     */
+    @Test
+    public void testCacheHonorsConfiguration() {
+        assertEquals(cache, region.getCache());
+
+        assertEquals(TimeUnit.SECONDS.toMillis(timeout), region.getTimeout());
+        verify(instance, atLeastOnce()).getConfig();
+        // ensure a topic is not requested
+        verify(instance, never()).getTopic(anyString());
+        verify(config, atLeastOnce()).findMapConfig(eq(REGION_NAME));
+        // should have been retrieved by the region itself
+        verify(mapConfig, times(2)).getTimeToLiveSeconds();
+    }
+
+    @Test
+    public void testEvict() {
+        region.evict("evictionKey");
+    }
+
+    @Test
+    public void testEvict_withException() {
+        doThrow(new OperationTimeoutException("expected exception")).when(cache).remove(eq("evictionKey"));
+        region.evict("evictionKey");
+    }
+
+    @Test
+    public void testEvictAll() {
+        region.evictAll();
+    }
+
+    @Test
+    public void testEvictAll_withException() {
+        doThrow(new OperationTimeoutException("expected exception")).when(cache).clear();
+        region.evictAll();
+    }
+
+    @Test
+    public void testGet() {
+        assertNull(region.get(null, "getKey"));
+    }
+
+    @Test
+    public void testGet_withException() {
+        doThrow(new OperationTimeoutException("expected exception")).when(cache).get(eq("getKey"), anyLong());
+        assertNull(region.get(null, "getKey"));
+    }
+
+    @Test
+    public void testPut() {
+        region.put(null, "putKey", "putValue");
+        verify(cache).put(eq("putKey"), eq("putValue"), anyLong(), any());
+    }
+
+    @Test
+    public void testPut_withException() {
+        doThrow(new OperationTimeoutException("expected exception"))
+                .when(cache).put(eq("putKey"), eq("putValue"), anyLong(), any());
+        region.put(null, "putKey", "putValue");
+        verify(cache).put(eq("putKey"), eq("putValue"), anyLong(), any());
+    }
+
+    @Test
+    public void testCache() {
+        assertEquals(cache, region.getCache());
+    }
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/serialization/ExpiryMarkerTest.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/serialization/ExpiryMarkerTest.java
@@ -1,0 +1,79 @@
+package com.hazelcast.hibernate.serialization;
+
+import org.hibernate.internal.util.compare.ComparableComparator;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ExpiryMarkerTest {
+
+    @Test
+    public void testIsReplaceableByTimestampBeforeTimeout() throws Exception {
+        ExpiryMarker marker = new ExpiryMarker(null, 100L, "the-marker-id");
+        assertFalse("marker is not replaceable when it hasn't timed out", marker.isReplaceableBy(99L, null, null));
+    }
+
+    @Test
+    public void testIsReplaceableByTimestampEqualTimeout() throws Exception {
+        ExpiryMarker marker = new ExpiryMarker(null, 100L, "the-marker-id");
+        assertFalse("marker is not replaceable when it hasn't timed out", marker.isReplaceableBy(100L, null, null));
+    }
+
+    @Test
+    public void testIsReplaceableByTimestampAfterTimeout() throws Exception {
+        ExpiryMarker marker = new ExpiryMarker(null, 100L, "the-marker-id");
+        assertTrue("marker is replaceable when it has timed out", marker.isReplaceableBy(101L, null, null));
+    }
+
+    @Test
+    public void testIsReplaceableByTimestampBeforeExpiredTimestamp() throws Exception {
+        ExpiryMarker marker = new ExpiryMarker(null, 150L, "the-marker-id").expire(100L);
+        assertFalse("marker is not replaceable when it when timestamp before expiry",
+                marker.isReplaceableBy(99L, null, null));
+    }
+
+    @Test
+    public void testIsReplaceableByTimestampEqualExpiredTimestamp() throws Exception {
+        ExpiryMarker marker = new ExpiryMarker(null, 150L, "the-marker-id").expire(100L);
+        assertFalse("marker is not replaceable when it when timestamp equal to expiry",
+                marker.isReplaceableBy(100L, null, null));
+    }
+
+    @Test
+    public void testIsReplaceableByTimestampAfterExpiredTimestamp() throws Exception {
+        ExpiryMarker marker = new ExpiryMarker(null, 150L, "the-marker-id").expire(100L);
+        assertTrue("marker is replaceable when it when timestamp after expiry",
+                marker.isReplaceableBy(101L, null, null));
+    }
+
+    @Test
+    public void testIsReplaceableByVersionBefore() throws Exception {
+        ExpiryMarker marker = new ExpiryMarker(10, 150L, "the-marker-id").expire(100L);
+        assertFalse("marker is replaceable when it when version before",
+                marker.isReplaceableBy(101L, 9, ComparableComparator.INSTANCE));
+    }
+
+    @Test
+    public void testIsReplaceableByVersionEqual() throws Exception {
+        ExpiryMarker marker = new ExpiryMarker(10, 150L, "the-marker-id").expire(100L);
+        assertFalse("marker is replaceable when it when version equal",
+                marker.isReplaceableBy(101L, 10, ComparableComparator.INSTANCE));
+    }
+
+    @Test
+    public void testIsReplaceableByVersionAfter() throws Exception {
+        ExpiryMarker marker = new ExpiryMarker(10, 150L, "the-marker-id").expire(100L);
+        assertTrue("marker is replaceable when it when version after",
+                marker.isReplaceableBy(99L, 11, ComparableComparator.INSTANCE));
+    }
+
+    @Test
+    public void testMatchesOnlyUsesMarkerId() throws Exception {
+        ExpiryMarker marker = new ExpiryMarker(10, 150L, "the-marker-id");
+        assertTrue(marker.matches(marker));
+        assertTrue(marker.matches(marker.expire(100)));
+        assertTrue(marker.matches(marker.markForExpiration(100L, "some-other-marker-id")));
+        assertTrue(marker.matches(new ExpiryMarker(9, 100L, "the-marker-id")));
+        assertFalse(marker.matches(new ExpiryMarker(10, 150L, "some-other-marker-id")));
+    }
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/serialization/HibernateSerializationHookAvailableTest.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/serialization/HibernateSerializationHookAvailableTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.serialization;
+
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.impl.HazelcastInstanceImpl;
+import com.hazelcast.instance.impl.HazelcastInstanceProxy;
+import com.hazelcast.internal.serialization.impl.AbstractSerializationService;
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.hibernate.cache.spi.entry.StandardCacheEntryImpl;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.ConcurrentMap;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class HibernateSerializationHookAvailableTest {
+
+    private static final Field ORIGINAL;
+    private static final Field TYPE_MAP;
+
+    static {
+        try {
+            ORIGINAL = HazelcastInstanceProxy.class.getDeclaredField("original");
+            ORIGINAL.setAccessible(true);
+
+            TYPE_MAP = AbstractSerializationService.class.getDeclaredField("typeMap");
+            TYPE_MAP.setAccessible(true);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @After
+    public void teardown() {
+        Hazelcast.shutdownAll();
+    }
+
+    @Test
+    public void testAutoregistrationOnHibernate5Available()
+            throws Exception {
+
+        HazelcastInstance hz = Hazelcast.newHazelcastInstance();
+        HazelcastInstanceImpl impl = (HazelcastInstanceImpl) ORIGINAL.get(hz);
+        SerializationService ss = impl.getSerializationService();
+        @SuppressWarnings("unchecked")
+        ConcurrentMap<Class, ?> typeMap = (ConcurrentMap) TYPE_MAP.get(ss);
+
+        boolean cacheEntrySerializerFound = false;
+        for (Class clazz : typeMap.keySet()) {
+            if (StandardCacheEntryImpl.class.equals(clazz)
+                    || "com.hazelcast.hibernate.serialization.CacheEntryImpl".equals(clazz.getName())) {
+                cacheEntrySerializerFound = true;
+            }
+        }
+
+        assertTrue("CacheEntry serializer not found", cacheEntrySerializerFound);
+    }
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/serialization/HibernateSerializationHookNonAvailableTest.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/serialization/HibernateSerializationHookNonAvailableTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.serialization;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.internal.util.FilteringClassLoader;
+import org.hibernate.cache.spi.entry.StandardCacheEntryImpl;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ConcurrentMap;
+
+import static org.junit.Assert.assertFalse;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class HibernateSerializationHookNonAvailableTest {
+
+    private static final Field ORIGINAL;
+    private static final Field TYPE_MAP;
+    private static final Method GET_SERIALIZATION_SERVICE;
+
+    private static final ClassLoader FILTERING_CLASS_LOADER;
+
+    static {
+        try {
+            List<String> excludes = Collections.singletonList("org.hibernate");
+            FILTERING_CLASS_LOADER = new FilteringClassLoader(excludes, "com.hazelcast");
+
+            String hazelcastInstanceImplClassName = "com.hazelcast.instance.impl.HazelcastInstanceImpl";
+            Class<?> hazelcastInstanceImplClass = FILTERING_CLASS_LOADER.loadClass(hazelcastInstanceImplClassName);
+            GET_SERIALIZATION_SERVICE = hazelcastInstanceImplClass.getMethod("getSerializationService");
+
+            String hazelcastInstanceProxyClassName = "com.hazelcast.instance.impl.HazelcastInstanceProxy";
+            Class<?> hazelcastInstanceProxyClass = FILTERING_CLASS_LOADER.loadClass(hazelcastInstanceProxyClassName);
+            ORIGINAL = hazelcastInstanceProxyClass.getDeclaredField("original");
+            ORIGINAL.setAccessible(true);
+
+            String serializationServiceImplClassName = "com.hazelcast.internal.serialization.impl.AbstractSerializationService";
+            Class<?> serializationServiceImplClass = FILTERING_CLASS_LOADER.loadClass(serializationServiceImplClassName);
+            TYPE_MAP = serializationServiceImplClass.getDeclaredField("typeMap");
+            TYPE_MAP.setAccessible(true);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testAutoregistrationOnHibernate5NonAvailable()
+            throws Exception {
+
+        Thread thread = Thread.currentThread();
+        ClassLoader tccl = thread.getContextClassLoader();
+
+        Object config = null;
+        Method setClassLoader = null;
+        try {
+            thread.setContextClassLoader(FILTERING_CLASS_LOADER);
+
+            Class<?> configClazz = FILTERING_CLASS_LOADER.loadClass("com.hazelcast.config.Config");
+            config = configClazz.newInstance();
+            setClassLoader = configClazz.getDeclaredMethod("setClassLoader", ClassLoader.class);
+
+            setClassLoader.invoke(config, FILTERING_CLASS_LOADER);
+
+            Class<?> hazelcastClazz = FILTERING_CLASS_LOADER.loadClass("com.hazelcast.core.Hazelcast");
+            Method newHazelcastInstance = hazelcastClazz.getDeclaredMethod("newHazelcastInstance", configClazz);
+
+            Object hz = newHazelcastInstance.invoke(hazelcastClazz, config);
+            Object impl = ORIGINAL.get(hz);
+            Object serializationService = GET_SERIALIZATION_SERVICE.invoke(impl);
+            //noinspection unchecked
+            ConcurrentMap<Class, ?> typeMap = (ConcurrentMap<Class, ?>) TYPE_MAP.get(serializationService);
+            boolean cacheEntrySerializerFound = false;
+            for (Class clazz : typeMap.keySet()) {
+                if (StandardCacheEntryImpl.class.equals(clazz)
+                        || "com.hazelcast.hibernate.serialization.CacheEntryImpl".equals(clazz.getName())) {
+                    cacheEntrySerializerFound = true;
+                }
+            }
+
+            hazelcastClazz.getDeclaredMethod("shutdownAll").invoke(impl);
+
+            assertFalse("CacheEntry serializer found", cacheEntrySerializerFound);
+        } finally {
+            if (config != null && setClassLoader != null) {
+                setClassLoader.invoke(config, tccl);
+            }
+
+            thread.setContextClassLoader(tccl);
+        }
+    }
+}

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/serialization/ValueTest.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/serialization/ValueTest.java
@@ -1,0 +1,80 @@
+package com.hazelcast.hibernate.serialization;
+
+import org.hibernate.internal.util.compare.ComparableComparator;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ValueTest {
+
+    @Test
+    public void testGetValue() throws Exception {
+        String expectedValue = "Some value";
+        Value value = new Value(null, 100L, expectedValue);
+        assertEquals(expectedValue, value.getValue());
+    }
+
+    @Test
+    public void testGetValueWithTimestampBefore() throws Exception {
+        String expectedValue = "Some value";
+        Value value = new Value(null, 100L, expectedValue);
+        assertNull(value.getValue(99L));
+    }
+
+    @Test
+    public void testGetValueWithTimestampEqual() throws Exception {
+        String expectedValue = "Some value";
+        Value value = new Value(null, 100L, expectedValue);
+        assertEquals(expectedValue, value.getValue(100L));
+    }
+
+    @Test
+    public void testGetValueWithTimestampAfter() throws Exception {
+        String expectedValue = "Some value";
+        Value value = new Value(null, 100L, expectedValue);
+        assertEquals(expectedValue, value.getValue(101L));
+    }
+
+    @Test
+    public void testIsReplaceableByTimestampBefore() throws Exception {
+        String expectedValue = "Some value";
+        Value value = new Value(null, 100L, expectedValue);
+        assertFalse(value.isReplaceableBy(99L, null, null));
+    }
+
+    @Test
+    public void testIsReplaceableByTimestampEqual() throws Exception {
+        String expectedValue = "Some value";
+        Value value = new Value(null, 100L, expectedValue);
+        assertTrue(value.isReplaceableBy(100L, null, null));
+    }
+
+    @Test
+    public void testIsReplaceableByTimestampAfter() throws Exception {
+        String expectedValue = "Some value";
+        Value value = new Value(null, 100L, expectedValue);
+        assertTrue(value.isReplaceableBy(101L, null, null));
+    }
+
+    @Test
+    public void testIsReplaceableByVersionBefore() throws Exception {
+        String expectedValue = "Some value";
+        Value value = new Value(10, 100L, expectedValue);
+        assertFalse(value.isReplaceableBy(99L, 9, ComparableComparator.INSTANCE));
+    }
+
+    @Test
+    public void testIsReplaceableByVersionEqual() throws Exception {
+        String expectedValue = "Some value";
+        Value value = new Value(10, 100L, expectedValue);
+        assertFalse(value.isReplaceableBy(101L, 10, ComparableComparator.INSTANCE));
+    }
+
+    @Test
+    public void testIsReplaceableByVersionAfter() throws Exception {
+        String expectedValue = "Some value";
+        Value value = new Value(10, 100L, expectedValue);
+        assertTrue(value.isReplaceableBy(99L, 11, ComparableComparator.INSTANCE));
+    }
+
+}

--- a/hazelcast-hibernate52/src/test/resources/hazelcast-client-custom.xml
+++ b/hazelcast-hibernate52/src/test/resources/hazelcast-client-custom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 Hazelcast Inc.
+  ~
+  ~ Licensed under the Hazelcast Community License (the "License"); you may not use
+  ~ this file except in compliance with the License. You may obtain a copy of the
+  ~ License at
+  ~
+  ~ http://hazelcast.com/hazelcast-community-license
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OF ANY KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations under the License.
+  -->
+
+<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-4.0.xsd"
+                  xmlns="http://www.hazelcast.com/schema/client-config"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+</hazelcast-client>

--- a/hazelcast-hibernate52/src/test/resources/hazelcast-custom.xml
+++ b/hazelcast-hibernate52/src/test/resources/hazelcast-custom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 Hazelcast Inc.
+  ~
+  ~ Licensed under the Hazelcast Community License (the "License"); you may not use
+  ~ this file except in compliance with the License. You may obtain a copy of the
+  ~ License at
+  ~
+  ~ http://hazelcast.com/hazelcast-community-license
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OF ANY KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations under the License.
+  -->
+
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd">
+    <cluster-name>dev-custom</cluster-name>
+    <network>
+        <port auto-increment="true">5701</port>
+        <join>
+            <multicast enabled="false">
+                <multicast-group>224.2.2.3</multicast-group>
+                <multicast-port>54327</multicast-port>
+            </multicast>
+            <tcp-ip enabled="true">
+                <interface>127.0.0.1</interface>
+            </tcp-ip>
+        </join>
+        <interfaces enabled="false">
+            <interface>10.3.17.*</interface>
+        </interfaces>
+    </network>
+    <map name="default">
+        <!--
+            Number of backups. If 1 is set as the backup-count for example,
+            then all entries of the map will be copied to another JVM for
+            fail-safety. Valid numbers are 0 (no backup), 1, 2, 3.
+        -->
+        <backup-count>1</backup-count>
+        <!--
+        eviction-policy:
+            Valid values are:
+            NONE (no eviction),
+            LRU (Least Recently Used),
+            LFU (Least Frequently Used).
+            NONE is the default.
+        size:
+            Maximum size of the map. When max size is reached,
+            map is evicted based on the policy defined.
+            Any integer between 0 and Integer.MAX_VALUE. 0 means
+            Integer.MAX_VALUE. Default is 0.
+        -->
+        <eviction eviction-policy="NONE" size="0" />
+    </map>
+
+    <!-- Config for query cache -->
+    <map name="org.hibernate.cache.*">
+        <time-to-live-seconds>0</time-to-live-seconds>
+        <eviction size="50" />
+    </map>
+</hazelcast>

--- a/hazelcast-hibernate52/src/test/resources/hbm/DummyEntity.xml
+++ b/hazelcast-hibernate52/src/test/resources/hbm/DummyEntity.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright 2020 Hazelcast Inc.
+  ~
+  ~ Licensed under the Hazelcast Community License (the "License"); you may not use
+  ~ this file except in compliance with the License. You may obtain a copy of the
+  ~ License at
+  ~
+  ~ http://hazelcast.com/hazelcast-community-license
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OF ANY KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations under the License.
+  -->
+
+<!DOCTYPE hibernate-mapping PUBLIC
+        "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+        "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping package="com.hazelcast.hibernate.entity">
+    <class name="DummyEntity" table="dummy_entities">
+        <cache usage="%1$s"/>
+
+        <id name="id" column="uid" type="long" unsaved-value="null">
+            <generator class="assigned"/>
+        </id>
+        <version column="version" name="version" type="int"/>
+        <property name="name" type="string" length="100"/>
+        <property name="date" column="dummy_date" type="date"/>
+        <property name="value" column="dummy_value" type="double"/>
+
+        <set name="properties" lazy="false" cascade="all" inverse="true">
+            <cache usage="%1$s"/>
+            <key column="parent_uid"/>
+            <one-to-many class="com.hazelcast.hibernate.entity.DummyProperty"/>
+        </set>
+    </class>
+</hibernate-mapping>

--- a/hazelcast-hibernate52/src/test/resources/hbm/DummyProperty.xml
+++ b/hazelcast-hibernate52/src/test/resources/hbm/DummyProperty.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright 2020 Hazelcast Inc.
+  ~
+  ~ Licensed under the Hazelcast Community License (the "License"); you may not use
+  ~ this file except in compliance with the License. You may obtain a copy of the
+  ~ License at
+  ~
+  ~ http://hazelcast.com/hazelcast-community-license
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OF ANY KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations under the License.
+  -->
+
+<!DOCTYPE hibernate-mapping PUBLIC
+        "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+        "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping package="com.hazelcast.hibernate.entity">
+    <class name="DummyProperty" table="dummy_props">
+        <cache usage="%1$s"/>
+
+        <id name="id" column="uid" type="long" unsaved-value="null">
+            <generator class="native"/>
+        </id>
+        <version column="version" name="version" type="int"/>
+        <property name="key" type="string" length="100"/>
+
+        <many-to-one name="entity" class="com.hazelcast.hibernate.entity.DummyEntity"
+                     column="parent_uid"/>
+    </class>
+</hibernate-mapping>

--- a/hazelcast-hibernate52/src/test/resources/test-hibernate-client.cfg.xml
+++ b/hazelcast-hibernate52/src/test/resources/test-hibernate-client.cfg.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2020 Hazelcast Inc.
+  ~
+  ~ Licensed under the Hazelcast Community License (the "License"); you may not use
+  ~ this file except in compliance with the License. You may obtain a copy of the
+  ~ License at
+  ~
+  ~ http://hazelcast.com/hazelcast-community-license
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OF ANY KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations under the License.
+  -->
+
+<!DOCTYPE hibernate-configuration PUBLIC
+        "-//Hibernate/Hibernate Configuration DTD 3.0//EN"
+        "classpath://org/hibernate/hibernate-configuration-3.0.dtd">
+
+<hibernate-configuration>
+    <session-factory>
+        <property name="hibernate.dialect">org.hibernate.dialect.HSQLDialect</property>
+        <property name="hibernate.connection.driver_class">org.hsqldb.jdbcDriver</property>
+        <property name="hibernate.connection.url">jdbc:hsqldb:mem:testdb</property>
+        <property name="hibernate.connection.username">sa</property>
+        <property name="hibernate.connection.password"/>
+
+        <property name="hibernate.connection.pool_size">2</property>
+        <property name="hibernate.show_sql">false</property>
+        <property name="hibernate.hbm2ddl.auto">create-drop</property>
+
+        <property name="hibernate.cache.use_second_level_cache">true</property>
+        <property name="hibernate.cache.use_query_cache">true</property>
+        <property name="hibernate.cache.use_minimal_puts">true</property>
+
+        <property name="hibernate.cache.hazelcast.use_native_client">true</property>
+        <property name="hibernate.cache.hazelcast.native_client_address">localhost</property>
+        <property name="hibernate.cache.hazelcast.native_client_cluster_name">dev-custom</property>
+        <property name="hibernate.cache.hazelcast.explicit_version_check">true</property>
+    </session-factory>
+</hibernate-configuration>

--- a/hazelcast-hibernate52/src/test/resources/test-hibernate.cfg.xml
+++ b/hazelcast-hibernate52/src/test/resources/test-hibernate.cfg.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2020 Hazelcast Inc.
+  ~
+  ~ Licensed under the Hazelcast Community License (the "License"); you may not use
+  ~ this file except in compliance with the License. You may obtain a copy of the
+  ~ License at
+  ~
+  ~ http://hazelcast.com/hazelcast-community-license
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OF ANY KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations under the License.
+  -->
+
+<!DOCTYPE hibernate-configuration PUBLIC
+        "-//Hibernate/Hibernate Configuration DTD 3.0//EN"
+        "classpath://org/hibernate/hibernate-configuration-3.0.dtd">
+
+<hibernate-configuration>
+    <session-factory>
+        <property name="hibernate.dialect">org.hibernate.dialect.HSQLDialect</property>
+        <property name="hibernate.connection.driver_class">org.hsqldb.jdbcDriver</property>
+        <property name="hibernate.connection.url">jdbc:hsqldb:mem:testdb</property>
+        <property name="hibernate.connection.username">sa</property>
+        <property name="hibernate.connection.password"/>
+
+        <property name="hibernate.connection.pool_size">2</property>
+        <property name="hibernate.show_sql">false</property>
+        <property name="hibernate.hbm2ddl.auto">create-drop</property>
+
+        <property name="hibernate.cache.use_second_level_cache">true</property>
+        <property name="hibernate.cache.use_query_cache">true</property>
+        <property name="hibernate.cache.use_minimal_puts">true</property>
+
+        <property name="hibernate.cache.hazelcast.configuration_file_path">hazelcast-custom.xml</property>
+    </session-factory>
+</hibernate-configuration>

--- a/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/RegionFactoryQueryCacheEvictionSlowTest.java
+++ b/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/RegionFactoryQueryCacheEvictionSlowTest.java
@@ -97,7 +97,7 @@ public class RegionFactoryQueryCacheEvictionSlowTest extends HibernateSlowTestSu
         QueryResultsRegionTemplate regionTemplate = (QueryResultsRegionTemplate) (((SessionFactoryImpl) sf).getCache()).getDefaultQueryResultsCache().getRegion();
         RegionCache cache = ((HazelcastStorageAccessImpl) regionTemplate.getStorageAccess()).getDelegate();
 
-        await().atMost(1, TimeUnit.SECONDS)
+        await().atMost(5, TimeUnit.SECONDS)
           .until(() -> numberOfEntities == cache.getElementCountInMemory());
 
         await()


### PR DESCRIPTION
Modules should not "reuse" tests from other modules, especially if these tests need to be cherry-picked, excluded, or overridden. This introduces confusion not only for developers but even for the tooling which recognizes test-sources of `hazelcast-hibernate5` as `hazelcast-hibernate52`'s, etc.

Moving related tests from `hazelcast-hibernate5` into `hazelcast-hibernate52` as a first step to removing tight coupling of `hazelcast-hibernate52` and `hazelcast-hibernate53` to `hazelcast-hibernate5 `, and getting rid of copy-pasting class files between modules.



