### PR TITLE
Decouple hazelcast-hibernate52 from hazelcast-hibernate5

### DIFF
--- a/hazelcast-hibernate52/pom.xml
+++ b/hazelcast-hibernate52/pom.xml
@@ -41,32 +41,6 @@
                 <version>${maven.resources.plugin.version}</version>
                 <executions>
                     <execution>
-                        <id>copy-sources</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>copy-resources</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${project.build.directory}/generated-sources</outputDirectory>
-                            <overwrite>false</overwrite>
-                            <resources>
-                                <resource>
-                                    <directory>../hazelcast-hibernate5/src/main/java</directory>
-                                    <excludes>
-                                        <exclude>com/hazelcast/hibernate/region/AbstractGeneralRegion.java</exclude>
-                                        <exclude>com/hazelcast/hibernate/region/CollectionRegionAccessStrategyAdapter.java</exclude>
-                                        <exclude>com/hazelcast/hibernate/region/HazelcastCacheKeysFactory.java</exclude>
-                                        <exclude>com/hazelcast/hibernate/region/NaturalIdRegionAccessStrategyAdapter.java</exclude>
-                                        <exclude>com/hazelcast/hibernate/region/EntityRegionAccessStrategyAdapter.java</exclude>
-                                        <exclude>com/hazelcast/hibernate/serialization/Hibernate5CacheEntrySerializerHook.java</exclude>
-                                        <exclude>com/hazelcast/hibernate/serialization/Hibernate5CacheEntrySerializer.java</exclude>
-                                        <exclude>com/hazelcast/hibernate/serialization/Hibernate51CacheEntrySerializer.java</exclude>
-                                    </excludes>
-                                </resource>
-                            </resources>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>copy-resources</id>
                         <phase>generate-resources</phase>
                         <goals>

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.instance.DefaultHazelcastInstanceFactory;
+import com.hazelcast.hibernate.instance.IHazelcastInstanceFactory;
+import com.hazelcast.hibernate.instance.IHazelcastInstanceLoader;
+import com.hazelcast.hibernate.local.CleanupService;
+import com.hazelcast.hibernate.region.HazelcastQueryResultsRegion;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import org.hibernate.boot.spi.SessionFactoryOptions;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.QueryResultsRegion;
+import org.hibernate.cache.spi.RegionFactory;
+import org.hibernate.cache.spi.access.AccessType;
+
+import java.util.Properties;
+
+/**
+ * Abstract superclass of Hazelcast based {@link RegionFactory} implementations
+ */
+public abstract class AbstractHazelcastCacheRegionFactory implements RegionFactory {
+
+    protected HazelcastInstance instance;
+    protected CleanupService cleanupService;
+    private final ILogger log = Logger.getLogger(getClass());
+
+    private IHazelcastInstanceLoader instanceLoader;
+
+
+    public AbstractHazelcastCacheRegionFactory() {
+    }
+
+    public AbstractHazelcastCacheRegionFactory(final Properties properties) {
+        this();
+    }
+
+    public AbstractHazelcastCacheRegionFactory(final HazelcastInstance instance) {
+        this.instance = instance;
+    }
+
+    @Override
+    public final QueryResultsRegion buildQueryResultsRegion(final String regionName, final Properties properties)
+            throws CacheException {
+        HazelcastQueryResultsRegion region = new HazelcastQueryResultsRegion(instance, regionName, properties);
+        cleanupService.registerCache(region.getCache());
+        return region;
+    }
+
+    /**
+     * @return true - for a large cluster, unnecessary puts will most likely slow things down.
+     */
+    @Override
+    public boolean isMinimalPutsEnabledByDefault() {
+        return true;
+    }
+
+    @Override
+    public long nextTimestamp() {
+        return HazelcastTimestamper.nextTimestamp(instance);
+    }
+
+    @Override
+    public void start(final SessionFactoryOptions options, final Properties properties) throws CacheException {
+        log.info("Starting up " + getClass().getSimpleName());
+        if (instance == null || !instance.getLifecycleService().isRunning()) {
+            String defaultFactory = DefaultHazelcastInstanceFactory.class.getName();
+            String factoryName = properties.getProperty(CacheEnvironment.HAZELCAST_FACTORY, defaultFactory);
+            ClassLoader cl = Thread.currentThread().getContextClassLoader();
+            try {
+                Class<IHazelcastInstanceFactory> factory =
+                        (Class<IHazelcastInstanceFactory>) Class.forName(factoryName, true, cl);
+                instanceLoader = factory.newInstance().createInstanceLoader(properties);
+            } catch (ClassNotFoundException | IllegalAccessException | InstantiationException e) {
+                throw new CacheException("Failed to set up hazelcast instance factory", e);
+            }
+            instance = instanceLoader.loadInstance();
+        }
+        cleanupService = new CleanupService(instance.getName());
+    }
+
+    @Override
+    public void stop() {
+        if (instanceLoader != null) {
+            log.info("Shutting down " + getClass().getSimpleName());
+            instanceLoader.unloadInstance();
+            instance = null;
+            instanceLoader = null;
+        }
+        cleanupService.stop();
+    }
+
+    public HazelcastInstance getHazelcastInstance() {
+        return instance;
+    }
+
+    @Override
+    public AccessType getDefaultAccessType() {
+        return AccessType.READ_WRITE;
+    }
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/CacheEnvironment.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/CacheEnvironment.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.logging.Logger;
+import org.hibernate.cfg.Environment;
+import org.hibernate.internal.util.StringHelper;
+import org.hibernate.internal.util.config.ConfigurationHelper;
+
+import java.util.Properties;
+
+/**
+ * This class is used to help in setup the internal caches. It searches for configuration files
+ * and contains all property names for hibernate based configuration properties.
+ */
+public final class CacheEnvironment {
+
+    /**
+     * Legacy property to configure the path of the hazelcast.xml or hazelcast-client.xml configuration files
+     */
+    @Deprecated
+    public static final String CONFIG_FILE_PATH_LEGACY = Environment.CACHE_PROVIDER_CONFIG;
+
+    /**
+     * Property to configure the path of the hazelcast.xml or hazelcast-client.xml configuration files
+     */
+    public static final String CONFIG_FILE_PATH = "hibernate.cache.hazelcast.configuration_file_path";
+
+    /**
+     * Property to configure weather a Hazelcast client or node will be used for connection to the cluster
+     */
+    public static final String USE_NATIVE_CLIENT = "hibernate.cache.hazelcast.use_native_client";
+
+    /**
+     * Property to configure the address for the Hazelcast client to connect to
+     */
+    public static final String NATIVE_CLIENT_ADDRESS = "hibernate.cache.hazelcast.native_client_address";
+
+    /**
+     * Property to configure Hazelcast client cluster name
+     */
+    public static final String NATIVE_CLIENT_CLUSTER_NAME = "hibernate.cache.hazelcast.native_client_cluster_name";
+
+    /**
+     * Property to configure Hazelcast client instance name
+     */
+    public static final String NATIVE_CLIENT_INSTANCE_NAME = "hibernate.cache.hazelcast.native_client_instance_name";
+
+    /**
+     * Property to configure if the HazelcastInstance should going to shutdown when the RegionFactory is being stopped
+     */
+    public static final String SHUTDOWN_ON_STOP = "hibernate.cache.hazelcast.shutdown_on_session_factory_close";
+
+    /**
+     * Property to configure the timeout delay before a lock eventually times out
+     */
+    public static final String LOCK_TIMEOUT = "hibernate.cache.hazelcast.lock_timeout";
+
+    /**
+     * Property to configure the Hazelcast instance internal name
+     */
+    public static final String HAZELCAST_INSTANCE_NAME = "hibernate.cache.hazelcast.instance_name";
+
+    /**
+     * Property to configure explicitly checks the CacheEntry's version while updating RegionCache.
+     * If new entry's version is not higher then previous, update will be cancelled.
+     */
+    public static final String EXPLICIT_VERSION_CHECK = "hibernate.cache.hazelcast.explicit_version_check";
+
+    /**
+     * Property to configure the Hazelcast operation timeout
+     */
+    public static final String HAZELCAST_OPERATION_TIMEOUT = "hazelcast.operation.call.timeout.millis";
+
+    /**
+     * Property to configure Hazelcast Shutdown Hook
+     */
+    public static final String HAZELCAST_SHUTDOWN_HOOK_ENABLED = "hazelcast.shutdownhook.enabled";
+
+    /**
+     * Property to configure which {@link com.hazelcast.hibernate.instance.IHazelcastInstanceFactory}
+     * that shall be used for creating
+     * {@link com.hazelcast.hibernate.instance.IHazelcastInstanceLoader hazelcast instance loaders}.
+     */
+    public static final String HAZELCAST_FACTORY = "hibernate.cache.hazelcast.factory";
+
+    // milliseconds
+    private static final int MAXIMUM_LOCK_TIMEOUT = 10000;
+
+    // one hour in milliseconds
+    private static final int DEFAULT_CACHE_TIMEOUT = (3600 * 1000);
+
+    private CacheEnvironment() {
+    }
+
+    public static String getConfigFilePath(final Properties props) {
+        String configResourcePath = ConfigurationHelper.getString(CacheEnvironment.CONFIG_FILE_PATH_LEGACY, props, null);
+        if (StringHelper.isEmpty(configResourcePath)) {
+            configResourcePath = ConfigurationHelper.getString(CacheEnvironment.CONFIG_FILE_PATH, props, null);
+        }
+        return configResourcePath;
+    }
+
+    public static String getInstanceName(final Properties props) {
+        return ConfigurationHelper.getString(HAZELCAST_INSTANCE_NAME, props, null);
+    }
+
+    public static boolean isNativeClient(final Properties props) {
+        return ConfigurationHelper.getBoolean(CacheEnvironment.USE_NATIVE_CLIENT, props, false);
+    }
+
+    public static int getDefaultCacheTimeoutInMillis() {
+        return DEFAULT_CACHE_TIMEOUT;
+    }
+
+    public static int getLockTimeoutInMillis(final Properties props) {
+        int timeout = -1;
+        try {
+            timeout = ConfigurationHelper.getInt(LOCK_TIMEOUT, props, -1);
+        } catch (Exception e) {
+            Logger.getLogger(CacheEnvironment.class).finest(e);
+        }
+        if (timeout < 0) {
+            timeout = MAXIMUM_LOCK_TIMEOUT;
+        }
+        return timeout;
+    }
+
+    public static boolean shutdownOnStop(final Properties props, final boolean defaultValue) {
+        return ConfigurationHelper.getBoolean(CacheEnvironment.SHUTDOWN_ON_STOP, props, defaultValue);
+    }
+
+    public static boolean isExplicitVersionCheckEnabled(final Properties props) {
+        return ConfigurationHelper.getBoolean(CacheEnvironment.EXPLICIT_VERSION_CHECK, props, false);
+    }
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/HazelcastCacheRegionFactory.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/HazelcastCacheRegionFactory.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.distributed.IMapRegionCache;
+import com.hazelcast.hibernate.region.HazelcastCollectionRegion;
+import com.hazelcast.hibernate.region.HazelcastEntityRegion;
+import com.hazelcast.hibernate.region.HazelcastNaturalIdRegion;
+import com.hazelcast.hibernate.region.HazelcastTimestampsRegion;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.CacheDataDescription;
+import org.hibernate.cache.spi.CollectionRegion;
+import org.hibernate.cache.spi.EntityRegion;
+import org.hibernate.cache.spi.NaturalIdRegion;
+import org.hibernate.cache.spi.RegionFactory;
+import org.hibernate.cache.spi.TimestampsRegion;
+
+import java.util.Properties;
+
+/**
+ * Simple RegionFactory implementation to return Hazelcast based Region implementations
+ */
+public class HazelcastCacheRegionFactory extends AbstractHazelcastCacheRegionFactory implements RegionFactory {
+
+    public HazelcastCacheRegionFactory() {
+    }
+
+    public HazelcastCacheRegionFactory(final HazelcastInstance instance) {
+        super(instance);
+    }
+
+    public HazelcastCacheRegionFactory(final Properties properties) {
+        super(properties);
+    }
+
+    @Override
+    public CollectionRegion buildCollectionRegion(final String regionName, final Properties properties,
+                                                  final CacheDataDescription metadata) throws CacheException {
+        return new HazelcastCollectionRegion<>(instance, regionName, properties, metadata,
+          new IMapRegionCache(regionName, instance, properties, metadata));
+    }
+
+    @Override
+    public EntityRegion buildEntityRegion(final String regionName, final Properties properties,
+                                          final CacheDataDescription metadata) throws CacheException {
+        return new HazelcastEntityRegion<>(instance, regionName, properties, metadata,
+          new IMapRegionCache(regionName, instance, properties, metadata));
+    }
+
+    @Override
+    public NaturalIdRegion buildNaturalIdRegion(final String regionName, final Properties properties,
+                                                final CacheDataDescription metadata) throws CacheException {
+        return new HazelcastNaturalIdRegion<>(instance, regionName, properties, metadata,
+          new IMapRegionCache(regionName, instance, properties, metadata));
+    }
+
+    @Override
+    public TimestampsRegion buildTimestampsRegion(final String regionName, final Properties properties)
+            throws CacheException {
+        return new HazelcastTimestampsRegion<>(instance, regionName, properties,
+          new IMapRegionCache(regionName, instance, properties, null));
+    }
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/HazelcastLocalCacheRegionFactory.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/HazelcastLocalCacheRegionFactory.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.local.LocalRegionCache;
+import com.hazelcast.hibernate.local.TimestampsRegionCache;
+import com.hazelcast.hibernate.region.HazelcastCollectionRegion;
+import com.hazelcast.hibernate.region.HazelcastEntityRegion;
+import com.hazelcast.hibernate.region.HazelcastNaturalIdRegion;
+import com.hazelcast.hibernate.region.HazelcastTimestampsRegion;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.CacheDataDescription;
+import org.hibernate.cache.spi.CollectionRegion;
+import org.hibernate.cache.spi.EntityRegion;
+import org.hibernate.cache.spi.NaturalIdRegion;
+import org.hibernate.cache.spi.RegionFactory;
+import org.hibernate.cache.spi.TimestampsRegion;
+
+import java.util.Properties;
+
+/**
+ * Simple RegionFactory implementation to return Hazelcast based local Region implementations
+ */
+public class HazelcastLocalCacheRegionFactory extends AbstractHazelcastCacheRegionFactory implements RegionFactory {
+
+    private static final int serialVersionUID = 1;
+
+    public HazelcastLocalCacheRegionFactory() {
+    }
+
+    public HazelcastLocalCacheRegionFactory(final HazelcastInstance instance) {
+        super(instance);
+    }
+
+    public HazelcastLocalCacheRegionFactory(final Properties properties) {
+        super(properties);
+    }
+
+    @Override
+    public CollectionRegion buildCollectionRegion(final String regionName, final Properties properties,
+                                                  final CacheDataDescription metadata) throws CacheException {
+        final HazelcastCollectionRegion<LocalRegionCache> region = new HazelcastCollectionRegion<>(instance,
+          regionName, properties, metadata, new LocalRegionCache(regionName, instance, metadata));
+        cleanupService.registerCache(region.getCache());
+        return region;
+    }
+
+    @Override
+    public EntityRegion buildEntityRegion(final String regionName, final Properties properties,
+                                          final CacheDataDescription metadata) throws CacheException {
+        final HazelcastEntityRegion<LocalRegionCache> region = new HazelcastEntityRegion<>(instance,
+          regionName, properties, metadata, new LocalRegionCache(regionName, instance, metadata));
+        cleanupService.registerCache(region.getCache());
+        return region;
+    }
+
+    @Override
+    public NaturalIdRegion buildNaturalIdRegion(final String regionName, final Properties properties,
+                                                final CacheDataDescription metadata) throws CacheException {
+        final HazelcastNaturalIdRegion<LocalRegionCache> region = new HazelcastNaturalIdRegion<>(
+          instance, regionName, properties, metadata, new LocalRegionCache(regionName, instance, metadata));
+        cleanupService.registerCache(region.getCache());
+
+        return region;
+    }
+
+    @Override
+    public TimestampsRegion buildTimestampsRegion(final String regionName, final Properties properties)
+            throws CacheException {
+        return new HazelcastTimestampsRegion<LocalRegionCache>(instance, regionName, properties,
+                new TimestampsRegionCache(regionName, instance));
+    }
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/HazelcastTimestamper.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/HazelcastTimestamper.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.logging.Logger;
+
+/**
+ * Helper class to create timestamps and calculate timeouts based on either Hazelcast
+ * configuration of by requesting values on the cluster.
+ */
+public final class HazelcastTimestamper {
+
+    private static final int SEC_TO_MS = 1000;
+
+    private HazelcastTimestamper() {
+    }
+
+    public static long nextTimestamp(final HazelcastInstance instance) {
+        if (instance == null) {
+            throw new RuntimeException("No Hazelcast instance!");
+        } else if (instance.getCluster() == null) {
+            throw new RuntimeException("Hazelcast instance has no cluster!");
+        }
+
+        // System time in ms.
+        return instance.getCluster().getClusterTime();
+    }
+
+    public static int getTimeout(final HazelcastInstance instance, final String regionName) {
+        try {
+            final MapConfig cfg = instance.getConfig().findMapConfig(regionName);
+            if (cfg.getTimeToLiveSeconds() > 0) {
+                // TTL in ms
+                return cfg.getTimeToLiveSeconds() * SEC_TO_MS;
+            }
+        } catch (UnsupportedOperationException e) {
+            // HazelcastInstance is instance of HazelcastClient.
+            Logger.getLogger(HazelcastTimestamper.class).finest(e);
+        }
+        return CacheEnvironment.getDefaultCacheTimeoutInMillis();
+    }
+
+    public static long getMaxOperationTimeout(final HazelcastInstance instance) {
+        String maxOpTimeoutProp = null;
+        try {
+            Config config = instance.getConfig();
+            maxOpTimeoutProp = config.getProperty(CacheEnvironment.HAZELCAST_OPERATION_TIMEOUT);
+        } catch (UnsupportedOperationException e) {
+            // HazelcastInstance is instance of HazelcastClient.
+            Logger.getLogger(HazelcastTimestamper.class).finest(e);
+        }
+        if (maxOpTimeoutProp != null) {
+            return Long.parseLong(maxOpTimeoutProp);
+        }
+        return Long.MAX_VALUE;
+    }
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/RegionCache.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/RegionCache.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import org.hibernate.cache.spi.access.SoftLock;
+
+import java.util.Map;
+
+/**
+ * This interface defines an internal cached region implementation as well as a mechanism
+ * to unmap the cache to an underlying Map data-structure
+ */
+public interface RegionCache {
+
+    Object get(final Object key, final long txTimestamp);
+
+    boolean insert(final Object key, final Object value, final Object currentVersion);
+
+    boolean put(final Object key, final Object value, final long txTimestamp, final Object version);
+
+    boolean update(final Object key, final Object newValue, final Object newVersion, final SoftLock lock);
+
+    boolean remove(final Object key);
+
+    SoftLock tryLock(final Object key, final Object version);
+
+    void unlock(final Object key, final SoftLock lock);
+
+    boolean contains(final Object key);
+
+    void clear();
+
+    long size();
+
+    long getSizeInMemory();
+
+    Map asMap();
+
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/VersionAwareMapMergePolicy.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/VersionAwareMapMergePolicy.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.merge.MergingValue;
+import com.hazelcast.spi.merge.SplitBrainMergePolicy;
+import org.hibernate.cache.spi.entry.CacheEntry;
+
+import java.io.IOException;
+
+/**
+ * A merge policy implementation to handle split brain remerges based on the timestamps stored in
+ * the values.
+ */
+public class VersionAwareMapMergePolicy implements SplitBrainMergePolicy<Object, MergingValue<Object>, Object> {
+
+    @Override
+    public Object merge(MergingValue<Object> mergingVal, MergingValue<Object> existingVal) {
+        final Object existingValue = existingVal != null ? existingVal.getValue() : null;
+        final Object mergingValue = mergingVal != null ? mergingVal.getValue() : null;
+        if (existingValue instanceof CacheEntry && mergingValue instanceof CacheEntry) {
+
+            final CacheEntry existingCacheEntry = (CacheEntry) existingValue;
+            final CacheEntry mergingCacheEntry = (CacheEntry) mergingValue;
+            final Object mergingVersionObject = mergingCacheEntry.getVersion();
+            final Object existingVersionObject = existingCacheEntry.getVersion();
+            if (mergingVersionObject instanceof Comparable && existingVersionObject instanceof Comparable) {
+
+                final Comparable mergingVersion = (Comparable) mergingVersionObject;
+                final Comparable existingVersion = (Comparable) existingVersionObject;
+
+                if (mergingVersion.compareTo(existingVersion) > 0) {
+                    return mergingValue;
+                } else {
+                    return existingValue;
+                }
+            }
+        }
+        return mergingValue;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+    }
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/access/AbstractAccessDelegate.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/access/AbstractAccessDelegate.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.access;
+
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.hibernate.RegionCache;
+import com.hazelcast.hibernate.region.AbstractTransactionalDataRegion;
+import com.hazelcast.hibernate.region.HazelcastRegion;
+import com.hazelcast.logging.ILogger;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.access.SoftLock;
+
+import java.util.Comparator;
+import java.util.Properties;
+
+/**
+ * Base implementation for consistency guarantees
+ *
+ * @param <T> implementation type of HazelcastRegion
+ */
+public abstract class AbstractAccessDelegate<T extends HazelcastRegion> implements AccessDelegate<T> {
+
+    protected final ILogger log;
+    protected final T hazelcastRegion;
+    protected final RegionCache cache;
+    protected final Comparator<Object> versionComparator;
+
+    protected AbstractAccessDelegate(final T hazelcastRegion, final Properties props) {
+        this.hazelcastRegion = hazelcastRegion;
+        log = hazelcastRegion.getLogger();
+        if (hazelcastRegion instanceof AbstractTransactionalDataRegion) {
+            this.versionComparator = ((AbstractTransactionalDataRegion) hazelcastRegion)
+                    .getCacheDataDescription().getVersionComparator();
+        } else {
+            this.versionComparator = null;
+        }
+        cache = hazelcastRegion.getCache();
+    }
+
+    @Override
+    public final T getHazelcastRegion() {
+        return hazelcastRegion;
+    }
+
+    @Override
+    public Object get(final Object key, final long txTimestamp) throws CacheException {
+        try {
+            return cache.get(key, txTimestamp);
+        } catch (HazelcastException e) {
+            if (log.isFinestEnabled()) {
+                log.finest("Could not read from Cache[" + hazelcastRegion.getName() + "]: " + e.getMessage());
+            }
+            return null;
+        }
+    }
+
+    @Override
+    public boolean putFromLoad(final Object key, final Object value, final long txTimestamp,
+                               final Object version) throws CacheException {
+        try {
+            return cache.put(key, value, txTimestamp, version);
+        } catch (HazelcastException e) {
+            if (log.isFinestEnabled()) {
+                log.finest("Could not put into Cache[" + hazelcastRegion.getName() + "]: " + e.getMessage());
+            }
+            return false;
+        }
+    }
+
+    @Override
+    public boolean putFromLoad(final Object key, final Object value, final long txTimestamp,
+                               final Object version, boolean minimalPuts) throws CacheException {
+        return putFromLoad(key, value, txTimestamp, version);
+    }
+
+    @Override
+    public void evict(final Object key) throws CacheException {
+        cache.remove(key);
+    }
+
+    @Override
+    public void evictAll() throws CacheException {
+        cache.clear();
+    }
+
+    /**
+     * NO-OP
+     */
+    @Override
+    public SoftLock lockRegion() throws CacheException {
+        return null;
+    }
+
+    @Override
+    public void unlockRegion(final SoftLock lock) throws CacheException {
+        cache.clear();
+    }
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/access/AccessDelegate.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/access/AccessDelegate.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.access;
+
+import com.hazelcast.hibernate.region.HazelcastRegion;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.access.SoftLock;
+
+/**
+ * This interface is used to implement basic transactional guarantees
+ *
+ * @param <T> implementation type of HazelcastRegion
+ */
+public interface AccessDelegate<T extends HazelcastRegion> {
+
+    /**
+     * Get the wrapped cache region
+     *
+     * @return The underlying region
+     */
+    T getHazelcastRegion();
+
+    /**
+     * Attempt to retrieve an object from the cache. Mainly used in attempting
+     * to resolve entities/collections from the second level cache.
+     *
+     * @param key         The key of the item to be retrieved.
+     * @param txTimestamp a timestamp prior to the transaction start time
+     * @return the cached object or <tt>null</tt>
+     * @throws CacheException
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
+     */
+    Object get(final Object key, final long txTimestamp) throws CacheException;
+
+    /**
+     * Called after an item has been inserted (before the transaction completes),
+     * instead of calling evict().
+     * This method is used by "synchronous" concurrency strategies.
+     *
+     * @param key     The item key
+     * @param value   The item
+     * @param version The item's version value
+     * @return Were the contents of the cache actual changed by this operation?
+     * @throws CacheException
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
+     */
+    boolean insert(final Object key, final Object value, final Object version) throws CacheException;
+
+    /**
+     * Called after an item has been inserted (after the transaction completes),
+     * instead of calling release().
+     * This method is used by "asynchronous" concurrency strategies.
+     *
+     * @param key     The item key
+     * @param value   The item
+     * @param version The item's version value
+     * @return Were the contents of the cache actual changed by this operation?
+     * @throws CacheException
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
+     */
+    boolean afterInsert(final Object key, final Object value, final Object version) throws CacheException;
+
+    /**
+     * Called after an item has been updated (before the transaction completes),
+     * instead of calling evict(). This method is used by "synchronous" concurrency
+     * strategies.
+     *
+     * @param key             The item key
+     * @param value           The item
+     * @param currentVersion  The item's current version value
+     * @param previousVersion The item's previous version value
+     * @return Were the contents of the cache actual changed by this operation?
+     * @throws CacheException
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
+     */
+    boolean update(final Object key, final Object value, final Object currentVersion, final Object previousVersion)
+            throws CacheException;
+
+    /**
+     * Called after an item has been updated (after the transaction completes),
+     * instead of calling release().  This method is used by "asynchronous"
+     * concurrency strategies.
+     *
+     * @param key             The item key
+     * @param value           The item
+     * @param currentVersion  The item's current version value
+     * @param previousVersion The item's previous version value
+     * @param lock            The lock previously obtained from {@link #lockItem}
+     * @return Were the contents of the cache actual changed by this operation?
+     * @throws CacheException
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
+     */
+    boolean afterUpdate(final Object key, final Object value, final Object currentVersion,
+                        final Object previousVersion, final SoftLock lock)
+            throws CacheException;
+
+    /**
+     * Attempt to cache an object, after loading from the database.
+     *
+     * @param key         The item key
+     * @param value       The item
+     * @param txTimestamp a timestamp prior to the transaction start time
+     * @param version     the item version number
+     * @return <tt>true</tt> if the object was successfully cached
+     * @throws CacheException
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
+     */
+    boolean putFromLoad(final Object key, final Object value, final long txTimestamp, final Object version)
+            throws CacheException;
+
+    /**
+     * Attempt to cache an object, after loading from the database, explicitly
+     * specifying the minimalPut behavior.
+     *
+     * @param key                The item key
+     * @param value              The item
+     * @param txTimestamp        a timestamp prior to the transaction start time
+     * @param version            the item version number
+     * @param minimalPutOverride Explicit minimalPut flag
+     * @return <tt>true</tt> if the object was successfully cached
+     * @throws CacheException
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
+     */
+    boolean putFromLoad(final Object key, final Object value, final long txTimestamp, final Object version,
+                        final boolean minimalPutOverride) throws CacheException;
+
+    /**
+     * Called after an item has become stale (before the transaction completes).
+     * This method is used by "synchronous" concurrency strategies.
+     *
+     * @param key The key of the item to remove
+     * @throws CacheException
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
+     */
+    void remove(final Object key) throws CacheException;
+
+    /**
+     * Called to evict data from the entire region
+     *
+     * @throws CacheException
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
+     */
+    void removeAll() throws CacheException;
+
+    /**
+     * Forcibly evict an item from the cache immediately without regard for transaction
+     * isolation.
+     *
+     * @param key The key of the item to remove
+     * @throws CacheException
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
+     */
+    void evict(final Object key) throws CacheException;
+
+    /**
+     * Forcibly evict all items from the cache immediately without regard for transaction
+     * isolation.
+     *
+     * @throws CacheException
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
+     */
+    void evictAll() throws CacheException;
+
+    /**
+     * We are going to attempt to update/delete the keyed object. This
+     * method is used by "asynchronous" concurrency strategies.
+     * <p/>
+     * The returned object must be passed back to release(), to release the
+     * lock. Concurrency strategies which do not support client-visible
+     * locks may silently return null.
+     *
+     * @param key     The key of the item to lock
+     * @param version The item's current version value
+     * @return A representation of our lock on the item; or null.
+     * @throws CacheException
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
+     */
+    SoftLock lockItem(final Object key, final Object version) throws CacheException;
+
+    /**
+     * Lock the entire region
+     *
+     * @return A representation of our lock on the item; or null.
+     * @throws CacheException
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
+     */
+    SoftLock lockRegion() throws CacheException;
+
+    /**
+     * Called when we have finished the attempted update/delete (which may or
+     * may not have been successful), after transaction completion.  This method
+     * is used by "asynchronous" concurrency strategies.
+     *
+     * @param key  The item key
+     * @param lock The lock previously obtained from {@link #lockItem}
+     * @throws CacheException
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
+     */
+    void unlockItem(final Object key, final SoftLock lock) throws CacheException;
+
+    /**
+     * Called after we have finished the attempted invalidation of the entire
+     * region
+     *
+     * @param lock The lock previously obtained from {@link #lockRegion}
+     * @throws CacheException
+     *          Propagated from underlying {@link org.hibernate.cache.spi.Region}
+     */
+    void unlockRegion(final SoftLock lock) throws CacheException;
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/access/NonStrictReadWriteAccessDelegate.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/access/NonStrictReadWriteAccessDelegate.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.access;
+
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.hibernate.region.HazelcastRegion;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.access.SoftLock;
+
+import java.util.Properties;
+
+/**
+ * Makes no guarantee of consistency between the cache and the database. Stale data from the cache is possible if expiry
+ * is not configured appropriately.
+ *
+ * @param <T> implementation type of HazelcastRegion
+ */
+public class NonStrictReadWriteAccessDelegate<T extends HazelcastRegion> extends AbstractAccessDelegate<T> {
+
+    public NonStrictReadWriteAccessDelegate(T hazelcastRegion, final Properties props) {
+        super(hazelcastRegion, props);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p/>
+     * Returns <code>false</code> since this is a non-strict read/write cache access strategy
+     */
+    @Override
+    public boolean afterInsert(final Object key, final Object value, final Object version) throws CacheException {
+        return false;
+    }
+
+    @Override
+    public boolean afterUpdate(final Object key, final Object value, final Object currentVersion,
+                               final Object previousVersion, final SoftLock lock) throws CacheException {
+        unlockItem(key, lock);
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p/>
+     * Returns <code>false</code> since this is an asynchronous cache access strategy.
+     */
+    @Override
+    public boolean insert(final Object key, final Object value, final Object version) throws CacheException {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p/>
+     * Removes the entry since this is a non-strict read/write cache strategy.
+     */
+    @Override
+    public boolean update(final Object key, final Object value, final Object currentVersion,
+                          final Object previousVersion) {
+        remove(key);
+        return false;
+    }
+
+    @Override
+    public void remove(final Object key) throws CacheException {
+        try {
+            cache.remove(key);
+        } catch (HazelcastException e) {
+            throw new CacheException("Operation timeout during remove operation from cache!", e);
+        }
+    }
+
+    @Override
+    public SoftLock lockItem(final Object key, final Object version) throws CacheException {
+        return null;
+    }
+
+    @Override
+    public void removeAll() throws CacheException {
+        cache.clear();
+    }
+
+    @Override
+    public void unlockItem(final Object key, final SoftLock lock) throws CacheException {
+        remove(key);
+    }
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/access/ReadOnlyAccessDelegate.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/access/ReadOnlyAccessDelegate.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.access;
+
+import com.hazelcast.hibernate.region.HazelcastRegion;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.access.SoftLock;
+
+import java.util.Properties;
+
+/**
+ * Guarantees that view is read-only and no updates can be made
+ *
+ * @param <T> implementation type of HazelcastRegion
+ */
+public class ReadOnlyAccessDelegate<T extends HazelcastRegion> extends NonStrictReadWriteAccessDelegate<T> {
+
+    public ReadOnlyAccessDelegate(T hazelcastRegion, final Properties props) {
+        super(hazelcastRegion, props);
+    }
+
+    @Override
+    public boolean afterInsert(final Object key, final Object value, final Object version) throws CacheException {
+        return cache.insert(key, value, version);
+    }
+
+    /**
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public boolean afterUpdate(final Object key, final Object value, final Object currentVersion,
+                               final Object previousVersion, final SoftLock lock) throws CacheException {
+        throw new UnsupportedOperationException("Cannot update an item in a read-only cache: "
+                + getHazelcastRegion().getName());
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p/>
+     * This cache is asynchronous hence a no-op
+     */
+    @Override
+    public boolean insert(final Object key, final Object value, final Object version) throws CacheException {
+        return false;
+    }
+
+    @Override
+    public SoftLock lockItem(final Object key, final Object version) throws CacheException {
+        return null;
+    }
+
+    /**
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public SoftLock lockRegion() throws CacheException {
+        throw new UnsupportedOperationException("Attempting to lock a read-only cache region: "
+                + getHazelcastRegion().getName());
+    }
+
+    @Override
+    public void removeAll() throws CacheException {
+        cache.clear();
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p/>
+     * Should be a no-op since this cache is read-only
+     */
+    @Override
+    public void unlockItem(final Object key, final SoftLock lock) throws CacheException {
+        /*
+         * To err on the safe side though, follow ReadOnlyEhcacheEntityRegionAccessStrategy which nevertheless evicts
+         * the key.
+         */
+        evict(key);
+    }
+
+    /**
+     * This will issue a log warning stating that an attempt was made to unlock a read-only cache region.
+     */
+    @Override
+    public void unlockRegion(final SoftLock lock) throws CacheException {
+        log.warning("Attempting to unlock a read-only cache region");
+    }
+
+    /**
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public boolean update(final Object key, final Object value, final Object currentVersion,
+                          final Object previousVersion) throws CacheException {
+        throw new UnsupportedOperationException("Attempting to update an item in a read-only cache: "
+                + getHazelcastRegion().getName());
+    }
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/access/ReadWriteAccessDelegate.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/access/ReadWriteAccessDelegate.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.access;
+
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.hibernate.region.HazelcastRegion;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.access.SoftLock;
+
+import java.util.Properties;
+
+/**
+ * Makes <b>READ COMMITTED</b> consistency guarantees even in a clustered environment.
+ *
+ * @param <T> implementation type of HazelcastRegion
+ */
+public class ReadWriteAccessDelegate<T extends HazelcastRegion> extends AbstractAccessDelegate<T> {
+
+
+    public ReadWriteAccessDelegate(T hazelcastRegion, final Properties props) {
+        super(hazelcastRegion, props);
+    }
+
+    @Override
+    public boolean afterInsert(final Object key, final Object value, final Object version) throws CacheException {
+        try {
+            return cache.insert(key, value, version);
+        } catch (HazelcastException e) {
+            if (log.isFinestEnabled()) {
+                log.finest("Could not insert into Cache[" + hazelcastRegion.getName() + "]: " + e.getMessage());
+            }
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p/>
+     * Called after <code>com.hazelcast.ReadWriteAccessDelegate.lockItem()</code>
+     */
+    @Override
+    public boolean afterUpdate(final Object key, final Object value, final Object currentVersion,
+                               final Object previousVersion, final SoftLock lock) throws CacheException {
+        try {
+            return cache.update(key, value, currentVersion, lock);
+        } catch (HazelcastException e) {
+            if (log.isFinestEnabled()) {
+                log.finest("Could not update Cache[" + hazelcastRegion.getName() + "]: " + e.getMessage());
+            }
+            return false;
+        }
+    }
+
+    /**
+     * This is an asynchronous cache access strategy.
+     * NO-OP
+     */
+    @Override
+    public boolean insert(final Object key, final Object value, final Object version) throws CacheException {
+        return false;
+    }
+
+    @Override
+    public SoftLock lockItem(final Object key, final Object version) throws CacheException {
+        return cache.tryLock(key, version);
+    }
+
+    @Override
+    public void unlockItem(final Object key, final SoftLock lock) throws CacheException {
+        cache.unlock(key, lock);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p/>
+     * A no-op since this is an asynchronous cache access strategy.
+     */
+    @Override
+    public boolean update(final Object key, final Object value, final Object currentVersion,
+                          final Object previousVersion) throws CacheException {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p/>
+     * A no-op since this is an asynchronous cache access strategy.
+     */
+    @Override
+    public void remove(final Object key) throws CacheException {
+    }
+
+    /**
+     * This is an asynchronous cache access strategy.
+     * NO-OP
+     */
+    @Override
+    public void removeAll() throws CacheException {
+    }
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/access/package-info.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/access/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+/**
+ * Provides access interfaces/classes for Hibernate.
+ * such as AccessDelegate, ReadWriteAccessDelegate.
+ */
+package com.hazelcast.hibernate.access;

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/distributed/IMapRegionCache.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/distributed/IMapRegionCache.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.distributed;
+
+import com.hazelcast.core.EntryView;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.CacheEnvironment;
+import com.hazelcast.hibernate.HazelcastTimestamper;
+import com.hazelcast.hibernate.RegionCache;
+import com.hazelcast.hibernate.serialization.Expirable;
+import com.hazelcast.hibernate.serialization.ExpiryMarker;
+import com.hazelcast.hibernate.serialization.MarkerWrapper;
+import com.hazelcast.hibernate.serialization.Value;
+import com.hazelcast.map.IMap;
+import org.hibernate.cache.spi.CacheDataDescription;
+import org.hibernate.cache.spi.access.SoftLock;
+
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.hazelcast.hibernate.HazelcastTimestamper.nextTimestamp;
+
+/**
+ * A {@link RegionCache} implementation based on the underlying IMap
+ * <p/>
+ * Note, IMap locks are intentionally not used in this class. Hibernate region caches make use of a concept
+ * called soft-locking which has the following properties:
+ * <ul>
+ *     <li>Multiple transactions can soft-lock an entry concurrently</li>
+ *     <li>While an entry is soft-locked, the value of the cache entry is always {@code null}</li>
+ *     <li>An entry is unlocked from a soft-lock when all transactions complete</li>
+ *     <li>An entry is unlocked if it reaches the configured lock timeout</li>
+ * </ul>
+ * These requirements are incompatible with IMap locks
+ */
+public class IMapRegionCache implements RegionCache {
+
+    private static final long COMPARISON_VALUE = 500;
+
+    private final String name;
+    private final HazelcastInstance hazelcastInstance;
+    private final IMap<Object, Expirable> map;
+    private final Comparator versionComparator;
+    private final int lockTimeout;
+    private final long tryLockAndGetTimeout;
+    private final AtomicLong markerIdCounter;
+
+    public IMapRegionCache(final String name, final HazelcastInstance hazelcastInstance,
+                           final Properties props, final CacheDataDescription metadata) {
+        this.name = name;
+        this.hazelcastInstance = hazelcastInstance;
+        this.versionComparator = metadata != null && metadata.isVersioned() ? metadata.getVersionComparator() : null;
+        this.map = hazelcastInstance.getMap(this.name);
+        lockTimeout = CacheEnvironment.getLockTimeoutInMillis(props);
+        final long maxOperationTimeout = HazelcastTimestamper.getMaxOperationTimeout(hazelcastInstance);
+        tryLockAndGetTimeout = Math.min(maxOperationTimeout, COMPARISON_VALUE);
+        markerIdCounter = new AtomicLong();
+    }
+
+    @Override
+    public Object get(final Object key, final long txTimestamp) {
+        Expirable entry = map.get(key);
+        return entry == null ? null : entry.getValue(txTimestamp);
+    }
+
+    @Override
+    public boolean insert(final Object key, final Object value, final Object currentVersion) {
+        return map.putIfAbsent(key, new Value(currentVersion, nextTimestamp(hazelcastInstance), value)) == null;
+    }
+
+    @Override
+    public boolean put(final Object key, final Object value, final long txTimestamp, final Object version) {
+        // Ideally this would be an entry processor. Unfortunately there is no guarantee that
+        // the versionComparator is Serializable.
+        //
+        // Alternatively this could be implemented using a `map.get` followed by `map.set` wrapped inside a
+        // `map.tryLock` block. Unfortunately this implementation was prone to `IllegalMonitorStateException` when
+        // the lock was released under heavy load or after network partitions. Hence this implementation now uses
+        // a spin loop around atomic operations.
+        long timeout = System.currentTimeMillis() + tryLockAndGetTimeout;
+        Value newEntry = new Value(version, txTimestamp, value);
+        do {
+            Expirable currentEntry = map.putIfAbsent(key, newEntry);
+            if (currentEntry == null) {
+                return true;
+            } else if (!currentEntry.isReplaceableBy(txTimestamp, version, versionComparator)) {
+                return false;
+            } else if (map.replace(key, currentEntry, newEntry)) {
+                return true;
+            }
+        } while (System.currentTimeMillis() < timeout);
+
+        return false;
+    }
+
+    @Override
+    public boolean update(final Object key, final Object newValue, final Object newVersion, final SoftLock lock) {
+        if (lock instanceof MarkerWrapper) {
+            final ExpiryMarker unwrappedMarker = ((MarkerWrapper) lock).getMarker();
+            return (Boolean) map.executeOnKey(key, new UpdateEntryProcessor(unwrappedMarker, newValue, newVersion,
+                    nextMarkerId(), nextTimestamp(hazelcastInstance)));
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean remove(final Object key) {
+        return map.remove(key) != null;
+    }
+
+    @Override
+    public SoftLock tryLock(final Object key, final Object version) {
+        long timeout = nextTimestamp(hazelcastInstance) + lockTimeout;
+        final ExpiryMarker marker = (ExpiryMarker) map.executeOnKey(key,
+                new LockEntryProcessor(nextMarkerId(), timeout, version));
+        return new MarkerWrapper(marker);
+    }
+
+    @Override
+    public void unlock(final Object key, final SoftLock lock) {
+        if (lock instanceof MarkerWrapper) {
+            final ExpiryMarker unwrappedMarker = ((MarkerWrapper) lock).getMarker();
+            map.executeOnKey(key, new UnlockEntryProcessor(unwrappedMarker, nextMarkerId(),
+                    nextTimestamp(hazelcastInstance)));
+        }
+    }
+
+    @Override
+    public boolean contains(final Object key) {
+        return map.containsKey(key);
+    }
+
+    @Override
+    public void clear() {
+        map.evictAll();
+    }
+
+    @Override
+    public long size() {
+        return map.size();
+    }
+
+    @Override
+    public long getSizeInMemory() {
+        long size = 0;
+        for (final Object key : map.keySet()) {
+            final EntryView entry = map.getEntryView(key);
+            if (entry != null) {
+                size += entry.getCost();
+            }
+        }
+        return size;
+    }
+
+    @Override
+    public Map asMap() {
+        return map;
+    }
+
+    private String nextMarkerId() {
+        return hazelcastInstance.getLocalEndpoint().getUuid().toString() + markerIdCounter.getAndIncrement();
+    }
+
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/distributed/LockEntryProcessor.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/distributed/LockEntryProcessor.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.distributed;
+
+import com.hazelcast.hibernate.serialization.Expirable;
+import com.hazelcast.hibernate.serialization.ExpiryMarker;
+import com.hazelcast.hibernate.serialization.HibernateDataSerializerHook;
+import com.hazelcast.map.EntryProcessor;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * A concrete implementation of {@link EntryProcessor} which soft-locks
+ * a region cached entry
+ */
+public class LockEntryProcessor implements EntryProcessor<Object, Expirable, Expirable>, IdentifiedDataSerializable {
+
+    private String nextMarkerId;
+    private long timeout;
+    private Object version;
+
+    public LockEntryProcessor() {
+    }
+
+    public LockEntryProcessor(final String nextMarkerId, final long timeout, final Object version) {
+        this.nextMarkerId = nextMarkerId;
+        this.timeout = timeout;
+        this.version = version;
+    }
+
+    @Override
+    public Expirable process(final Map.Entry<Object, Expirable> entry) {
+        Expirable expirable = entry.getValue();
+
+        if (expirable == null) {
+            expirable = new ExpiryMarker(version, timeout, nextMarkerId);
+        } else {
+            expirable = expirable.markForExpiration(timeout, nextMarkerId);
+        }
+
+        entry.setValue(expirable);
+
+        return expirable;
+    }
+
+    @Override
+    public void writeData(final ObjectDataOutput out) throws IOException {
+        out.writeUTF(nextMarkerId);
+        out.writeLong(timeout);
+        out.writeObject(version);
+    }
+
+    @Override
+    public void readData(final ObjectDataInput in) throws IOException {
+        nextMarkerId = in.readUTF();
+        timeout = in.readLong();
+        version = in.readObject();
+    }
+
+    @Override
+    public int getFactoryId() {
+        return HibernateDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return HibernateDataSerializerHook.LOCK;
+    }
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/distributed/UnlockEntryProcessor.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/distributed/UnlockEntryProcessor.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.distributed;
+
+import com.hazelcast.hibernate.serialization.Expirable;
+import com.hazelcast.hibernate.serialization.ExpiryMarker;
+import com.hazelcast.hibernate.serialization.HibernateDataSerializerHook;
+import com.hazelcast.map.EntryProcessor;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * A concrete implementation of {@link EntryProcessor} which unlocks
+ * a soft-locked region cached entry
+ */
+public class UnlockEntryProcessor implements EntryProcessor<Object, Expirable, Object>, IdentifiedDataSerializable {
+
+    private ExpiryMarker lock;
+    private String nextMarkerId;
+    private long timestamp;
+
+    public UnlockEntryProcessor() {
+    }
+
+    public UnlockEntryProcessor(final ExpiryMarker lock, final String nextMarkerId, final long timestamp) {
+        this.lock = lock;
+        this.nextMarkerId = nextMarkerId;
+        this.timestamp = timestamp;
+    }
+
+    @Override
+    public Object process(final Map.Entry<Object, Expirable> entry) {
+        Expirable expirable = entry.getValue();
+
+        if (expirable != null) {
+            if (expirable.matches(lock)) {
+                expirable = ((ExpiryMarker) expirable).expire(timestamp);
+            } else if (expirable.getValue() != null) {
+                // It's a value. Expire the value immediately. This prevents
+                // in-flight transactions from adding stale values to the cache
+                expirable = new ExpiryMarker(null, timestamp, nextMarkerId).expire(timestamp);
+            } else {
+                // It's a different marker. Leave it alone.
+                return null;
+            }
+            entry.setValue(expirable);
+        }
+
+        return null;
+    }
+
+    @Override
+    public void writeData(final ObjectDataOutput out) throws IOException {
+        out.writeObject(lock);
+        out.writeUTF(nextMarkerId);
+        out.writeLong(timestamp);
+    }
+
+    @Override
+    public void readData(final ObjectDataInput in) throws IOException {
+        lock = in.readObject();
+        nextMarkerId = in.readUTF();
+        timestamp = in.readLong();
+    }
+
+    @Override
+    public int getClassId() {
+        return HibernateDataSerializerHook.UNLOCK;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return HibernateDataSerializerHook.F_ID;
+    }
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/distributed/UpdateEntryProcessor.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/distributed/UpdateEntryProcessor.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.distributed;
+
+import com.hazelcast.hibernate.serialization.Expirable;
+import com.hazelcast.hibernate.serialization.ExpiryMarker;
+import com.hazelcast.hibernate.serialization.HibernateDataSerializerHook;
+import com.hazelcast.hibernate.serialization.Value;
+import com.hazelcast.map.EntryProcessor;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * A concrete implementation of {@link EntryProcessor} which attempts
+ * to update a region cache entry
+ */
+public class UpdateEntryProcessor implements EntryProcessor<Object, Expirable, Boolean>, IdentifiedDataSerializable {
+
+    private ExpiryMarker lock;
+    private Object newValue;
+    private Object newVersion;
+    private String nextMarkerId;
+    private long timestamp;
+
+    public UpdateEntryProcessor() {
+    }
+
+    public UpdateEntryProcessor(final ExpiryMarker lock, final Object newValue, final Object newVersion,
+                                final String nextMarkerId, final long timestamp) {
+        this.lock = lock;
+        this.nextMarkerId = nextMarkerId;
+        this.newValue = newValue;
+        this.newVersion = newVersion;
+        this.timestamp = timestamp;
+    }
+
+    @Override
+    public Boolean process(final Map.Entry<Object, Expirable> entry) {
+        Expirable expirable = entry.getValue();
+        boolean updated;
+
+        if (expirable == null) {
+            // Nothing there. The entry was evicted? It should be safe to replace it
+            expirable = new Value(newVersion, timestamp, newValue);
+            updated = true;
+        } else {
+            if (expirable.matches(lock)) {
+                final ExpiryMarker marker = (ExpiryMarker) expirable;
+                if (marker.isConcurrent()) {
+                    // Multiple transactions are attempting to update the same entry. Its highly
+                    // likely that the value we are attempting to set is invalid. Instead just
+                    // expire the entry and allow the next put to the cache to succeed if no more
+                    // transactions are in-flight.
+                    expirable = marker.expire(timestamp);
+                    updated = false;
+                } else {
+                    // Only one transaction attempted to update the entry so it is safe to replace
+                    // it with the value supplied
+                    expirable = new Value(newVersion, timestamp, newValue);
+                    updated = true;
+                }
+            } else if (expirable.getValue() == null) {
+                // It's a different marker, Leave it as is
+                return false;
+            } else {
+                // It's a value. We have no way to see which is correct so we expire the entry.
+                // It is expired instead of removed to prevent in progress transactions from
+                // putting stale values into the cache
+                expirable = new ExpiryMarker(newVersion, timestamp, nextMarkerId).expire(timestamp);
+                updated = false;
+            }
+        }
+
+        entry.setValue(expirable);
+        return updated;
+    }
+
+    @Override
+    public void writeData(final ObjectDataOutput out) throws IOException {
+        out.writeObject(lock);
+        out.writeObject(newValue);
+        out.writeObject(newVersion);
+        out.writeUTF(nextMarkerId);
+        out.writeLong(timestamp);
+    }
+
+    @Override
+    public void readData(final ObjectDataInput in) throws IOException {
+        lock = in.readObject();
+        newValue = in.readObject();
+        newVersion = in.readObject();
+        nextMarkerId = in.readUTF();
+        timestamp = in.readLong();
+    }
+
+    @Override
+    public int getClassId() {
+        return HibernateDataSerializerHook.UPDATE;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return HibernateDataSerializerHook.F_ID;
+    }
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/distributed/package-info.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/distributed/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+/**
+ * Provides distributed class for Hibernate.
+ * such as IMapRegionCache.
+ */
+package com.hazelcast.hibernate.distributed;

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/instance/DefaultHazelcastInstanceFactory.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/instance/DefaultHazelcastInstanceFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.instance;
+
+import com.hazelcast.hibernate.CacheEnvironment;
+import org.hibernate.cache.CacheException;
+
+import java.util.Properties;
+
+/**
+ * A factory that returns a {@link com.hazelcast.core.HazelcastInstance} depending on configuration either backed by Hazelcast
+ * client or node implementation.
+ */
+public final class DefaultHazelcastInstanceFactory implements IHazelcastInstanceFactory
+{
+    private static final String HZ_CLIENT_LOADER_CLASSNAME = "com.hazelcast.hibernate.instance.HazelcastClientLoader";
+    private static final String HZ_INSTANCE_LOADER_CLASSNAME = "com.hazelcast.hibernate.instance.HazelcastInstanceLoader";
+
+    public IHazelcastInstanceLoader createInstanceLoader(final Properties props) throws CacheException {
+        try {
+            Class loaderClass = getInstanceLoaderClass(props);
+            IHazelcastInstanceLoader instanceLoader = (IHazelcastInstanceLoader) loaderClass.newInstance();
+            instanceLoader.configure(props);
+            return instanceLoader;
+        } catch (Exception e) {
+            throw new CacheException(e);
+        }
+    }
+
+    private static Class getInstanceLoaderClass(final Properties props) throws ClassNotFoundException {
+        ClassLoader cl = DefaultHazelcastInstanceFactory.class.getClassLoader();
+        if (props != null && CacheEnvironment.isNativeClient(props)) {
+            return cl.loadClass(HZ_CLIENT_LOADER_CLASSNAME);
+        } else {
+            return cl.loadClass(HZ_INSTANCE_LOADER_CLASSNAME);
+        }
+    }
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/instance/HazelcastAccessor.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/instance/HazelcastAccessor.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.instance;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.AbstractHazelcastCacheRegionFactory;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.cache.spi.RegionFactory;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+
+/**
+ * Access underlying HazelcastInstance using Hibernate SessionFactory
+ *
+ * @deprecated Set instanceName for your Hazelcast instance and use
+ *             {@link com.hazelcast.core.Hazelcast#getHazelcastInstanceByName(String instanceName)} instead
+ */
+@Deprecated
+@SuppressWarnings("deprecation")
+public final class HazelcastAccessor {
+
+    static final ILogger LOGGER = Logger.getLogger(HazelcastAccessor.class);
+
+    private HazelcastAccessor() {
+    }
+
+    /**
+     * Tries to extract <code>HazelcastInstance</code> from <code>Session</code>.
+     *
+     * @param session the {@code Session} to retrieve the Hazelcast instance for
+     * @return Currently used <code>HazelcastInstance</code> or null if an error occurs.
+     */
+    public static HazelcastInstance getHazelcastInstance(final Session session) {
+        return getHazelcastInstance(session.getSessionFactory());
+    }
+
+    /**
+     * Tries to extract <code>HazelcastInstance</code> from <code>SessionFactory</code>.
+     *
+     * @param sessionFactory the {@code SessionFactory} to retrieve the Hazelcast instance for
+     * @return Currently used <code>HazelcastInstance</code> or null if an error occurs.
+     */
+    public static HazelcastInstance getHazelcastInstance(final SessionFactory sessionFactory) {
+        if (!(sessionFactory instanceof SessionFactoryImplementor)) {
+            LOGGER.warning("SessionFactory is expected to be instance of SessionFactoryImplementor.");
+            return null;
+        }
+        return getHazelcastInstance((SessionFactoryImplementor) sessionFactory);
+    }
+
+    /**
+     * Tries to extract <code>HazelcastInstance</code> from <code>SessionFactoryImplementor</code>.
+     *
+     * @param sessionFactory the {@code SessionFactoryImplementor} to retrieve the Hazelcast instance for
+     * @return currently used <code>HazelcastInstance</code> or null if an error occurs.
+     */
+    public static HazelcastInstance getHazelcastInstance(final SessionFactoryImplementor sessionFactory) {
+        final RegionFactory rf = sessionFactory.getSessionFactoryOptions()
+                .getServiceRegistry().getService(RegionFactory.class);
+        if (rf instanceof AbstractHazelcastCacheRegionFactory) {
+            return ((AbstractHazelcastCacheRegionFactory) rf).getHazelcastInstance();
+        } else {
+            LOGGER.warning("Current 2nd level cache implementation is not HazelcastCacheRegionFactory!");
+        }
+        return null;
+    }
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/instance/HazelcastClientLoader.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/instance/HazelcastClientLoader.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.instance;
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.XmlClientConfigBuilder;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.CacheEnvironment;
+import org.hibernate.cache.CacheException;
+import org.hibernate.internal.util.config.ConfigurationHelper;
+
+import java.io.IOException;
+import java.util.Properties;
+
+/**
+ * A factory implementation to build up a {@link HazelcastInstance}
+ * implementation using {@link HazelcastClient}.
+ */
+class HazelcastClientLoader implements IHazelcastInstanceLoader {
+
+    private static final int INITIAL_BACKOFF_MS = 2000;
+    private static final int MAX_BACKOFF_MS = 35000;
+    private static final double BACKOFF_MULTIPLIER = 1.5D;
+
+    private HazelcastInstance client;
+    private ClientConfig clientConfig;
+    private String instanceName;
+
+    @Override
+    public void configure(final Properties props) {
+        instanceName = ConfigurationHelper.getString(CacheEnvironment.NATIVE_CLIENT_INSTANCE_NAME, props, null);
+        if (instanceName != null) {
+            return;
+        }
+
+        String address = ConfigurationHelper.getString(CacheEnvironment.NATIVE_CLIENT_ADDRESS, props, null);
+        String clientClusterName = ConfigurationHelper.getString(CacheEnvironment.NATIVE_CLIENT_CLUSTER_NAME, props, null);
+        String configResourcePath = CacheEnvironment.getConfigFilePath(props);
+
+        if (configResourcePath != null) {
+            try {
+                clientConfig = new XmlClientConfigBuilder(configResourcePath).build();
+            } catch (IOException e) {
+                throw new HazelcastException("Could not load client configuration: " + configResourcePath, e);
+            }
+        } else {
+            clientConfig = new ClientConfig();
+        }
+        if (clientClusterName != null) {
+            clientConfig.setClusterName(clientClusterName);
+        }
+        if (address != null) {
+            clientConfig.getNetworkConfig().addAddress(address);
+        }
+
+        clientConfig.getNetworkConfig().setSmartRouting(true);
+        clientConfig.getNetworkConfig().setRedoOperation(true);
+
+        // Try to connect a cluster with intervals starting with 2 sec and multiplied by 1.5
+        // at each step. When the last waiting interval time exceeds 35 seconds, it fails.
+        // This corresponds to 8 trials in total.
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setInitialBackoffMillis(INITIAL_BACKOFF_MS);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setMaxBackoffMillis(MAX_BACKOFF_MS);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setMultiplier(BACKOFF_MULTIPLIER);
+    }
+
+    @Override
+    public HazelcastInstance loadInstance() throws CacheException {
+        if (instanceName != null) {
+            client = HazelcastClient.getHazelcastClientByName(instanceName);
+            if (client == null) {
+                throw new CacheException("No client with name [" + instanceName + "] could be found.");
+            }
+        } else {
+            client = HazelcastClient.newHazelcastClient(clientConfig);
+        }
+        return client;
+    }
+
+    @Override
+    public void unloadInstance() throws CacheException {
+        if (client == null) {
+            return;
+        }
+
+        try {
+            client.getLifecycleService().shutdown();
+            client = null;
+        } catch (Exception e) {
+            throw new CacheException(e);
+        }
+    }
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/instance/HazelcastInstanceLoader.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/instance/HazelcastInstanceLoader.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.instance;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.XmlConfigBuilder;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.CacheEnvironment;
+import com.hazelcast.internal.config.ConfigLoader;
+import com.hazelcast.internal.util.StringUtil;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import org.hibernate.cache.CacheException;
+
+import java.io.IOException;
+import java.util.Properties;
+
+/**
+ * A factory implementation to build up a {@link HazelcastInstance}
+ * implementation using {@link Hazelcast}.
+ */
+class HazelcastInstanceLoader implements IHazelcastInstanceLoader {
+
+    private static final ILogger LOGGER = Logger.getLogger(IHazelcastInstanceFactory.class);
+
+    private HazelcastInstance instance;
+    private Config config;
+    private boolean shutDown;
+    private String existingInstanceName;
+
+    @Override
+    public void configure(final Properties props) {
+        String instanceName = CacheEnvironment.getInstanceName(props);
+
+        if (!StringUtil.isNullOrEmptyAfterTrim(instanceName)) {
+            LOGGER.info("Using existing HazelcastInstance [" + instanceName + "].");
+            this.existingInstanceName = instanceName;
+        } else {
+            String configResourcePath = CacheEnvironment.getConfigFilePath(props);
+            if (!StringUtil.isNullOrEmptyAfterTrim(configResourcePath)) {
+                try {
+                    this.config = ConfigLoader.load(configResourcePath);
+                } catch (IOException e) {
+                    LOGGER.warning("IOException: " + e.getMessage());
+                }
+                if (config == null) {
+                    throw new CacheException("Could not find configuration file: " + configResourcePath);
+                }
+            } else {
+                this.config = new XmlConfigBuilder().build();
+            }
+        }
+
+        this.shutDown = CacheEnvironment.shutdownOnStop(props, (instanceName == null));
+    }
+
+    @Override
+    public HazelcastInstance loadInstance() throws CacheException {
+        if (existingInstanceName != null) {
+            instance = Hazelcast.getHazelcastInstanceByName(existingInstanceName);
+            if (instance == null) {
+                throw new CacheException("No instance with name [" + existingInstanceName + "] could be found.");
+            }
+        } else  {
+            instance = Hazelcast.newHazelcastInstance(config);
+        }
+        return instance;
+    }
+
+    @Override
+    public void unloadInstance() throws CacheException {
+        if (instance == null) {
+            return;
+        }
+        if (!shutDown) {
+            LOGGER.warning(CacheEnvironment.SHUTDOWN_ON_STOP + " property is set to 'false'. "
+                    + "Leaving current HazelcastInstance active! (Warning: Do not disable Hazelcast "
+                    + CacheEnvironment.HAZELCAST_SHUTDOWN_HOOK_ENABLED + " property!)");
+            return;
+        }
+        try {
+            instance.getLifecycleService().shutdown();
+            instance = null;
+        } catch (Exception e) {
+            throw new CacheException(e);
+        }
+    }
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/instance/IHazelcastInstanceFactory.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/instance/IHazelcastInstanceFactory.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.instance;
+
+import org.hibernate.cache.CacheException;
+
+import java.util.Properties;
+
+/**
+ * A hookable factory class to build up implementations of {@link IHazelcastInstanceLoader}
+ */
+public interface IHazelcastInstanceFactory {
+    IHazelcastInstanceLoader createInstanceLoader(final Properties props) throws CacheException;
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/instance/IHazelcastInstanceLoader.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/instance/IHazelcastInstanceLoader.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.instance;
+
+import com.hazelcast.core.HazelcastInstance;
+import org.hibernate.cache.CacheException;
+
+import java.util.Properties;
+
+/**
+ * Factory interface to build Hazelcast instances and configure them depending
+ * on configuration.
+ */
+public interface IHazelcastInstanceLoader {
+
+    /**
+     * Applies a set of properties to the factory
+     *
+     * @param props properties to apply
+     */
+    void configure(final Properties props);
+
+    /**
+     * Create a new {@link HazelcastInstance} or loads an already
+     * existing instances by it's name.
+     *
+     * @return new or existing HazelcastInstance (either client or node mode)
+     * @throws CacheException all exceptions wrapped to CacheException
+     */
+    HazelcastInstance loadInstance() throws CacheException;
+
+    /**
+     * Tries to shutdown a HazelcastInstance
+     *
+     * @throws CacheException all exceptions wrapped to CacheException
+     */
+    void unloadInstance() throws CacheException;
+}
+

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/instance/package-info.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/instance/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+/**
+ * Provides instance interfaces/classes for Hibernate.
+ */
+package com.hazelcast.hibernate.instance;

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/local/CleanupService.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/local/CleanupService.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.local;
+
+
+import com.hazelcast.instance.impl.OutOfMemoryErrorDispatcher;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * An internal service to clean cache regions
+ */
+public final class CleanupService {
+
+    /**
+     * Default fixed delay in seconds for scheduled job.
+     */
+    private static final long DEFAULT_FIXED_DELAY = 60L;
+
+    private final long fixedDelay;
+    private final String name;
+    private final ScheduledExecutorService executor;
+
+    public CleanupService(final String name) {
+        this(name, DEFAULT_FIXED_DELAY);
+    }
+
+    /**
+     * Visible for testing only.
+     */
+    public CleanupService(final String name, final long fixedDelay) {
+        this.fixedDelay = fixedDelay;
+        this.name = name;
+        executor = Executors.newSingleThreadScheduledExecutor(new CleanupThreadFactory());
+    }
+
+    public void registerCache(final LocalRegionCache cache) {
+        executor.scheduleWithFixedDelay(cache::cleanup, fixedDelay, fixedDelay, TimeUnit.SECONDS);
+    }
+
+    public void stop() {
+        executor.shutdownNow();
+    }
+
+    /**
+     * Internal ThreadFactory to create cleanup threads
+     */
+    private class CleanupThreadFactory implements ThreadFactory {
+
+        @Override
+        public Thread newThread(final Runnable r) {
+            final Thread thread = new CleanupThread(r, name + ".hibernate.cleanup");
+            thread.setDaemon(true);
+            return thread;
+        }
+    }
+
+    /**
+     * Runnable thread adapter to capture exceptions and notify Hazelcast about them
+     */
+    private static final class CleanupThread extends Thread {
+
+        private CleanupThread(final Runnable target, final String name) {
+            super(target, name);
+        }
+
+        @Override
+        public void run() {
+            try {
+                super.run();
+            } catch (OutOfMemoryError e) {
+                OutOfMemoryErrorDispatcher.onOutOfMemory(e);
+            }
+        }
+    }
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/local/Invalidation.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/local/Invalidation.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.local;
+
+
+import com.hazelcast.hibernate.serialization.HibernateDataSerializerHook;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
+
+/**
+ * An invalidation messages
+ */
+public class Invalidation implements IdentifiedDataSerializable {
+
+    private Object key;
+    private Object version;
+
+    public Invalidation() {
+    }
+
+    public Invalidation(final Object key, final Object version) {
+        this.key = key;
+        this.version = version;
+    }
+
+    public Object getKey() {
+        return key;
+    }
+
+    public Object getVersion() {
+        return version;
+    }
+
+    @Override
+    public void writeData(final ObjectDataOutput out) throws IOException {
+        out.writeObject(key);
+        out.writeObject(version);
+    }
+
+    @Override
+    public void readData(final ObjectDataInput in) throws IOException {
+        key = in.readObject();
+        version = in.readObject();
+    }
+
+    @Override
+    public int getFactoryId() {
+        return HibernateDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return HibernateDataSerializerHook.INVALIDATION;
+    }
+
+    @Override
+    public String toString() {
+        return "Invalidation{key=" + key + ", version=" + version + '}';
+    }
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/local/LocalRegionCache.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/local/LocalRegionCache.java
@@ -1,0 +1,437 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.local;
+
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.CacheEnvironment;
+import com.hazelcast.hibernate.HazelcastTimestamper;
+import com.hazelcast.hibernate.RegionCache;
+import com.hazelcast.hibernate.serialization.Expirable;
+import com.hazelcast.hibernate.serialization.ExpiryMarker;
+import com.hazelcast.hibernate.serialization.MarkerWrapper;
+import com.hazelcast.hibernate.serialization.Value;
+import com.hazelcast.internal.util.Clock;
+import com.hazelcast.internal.util.EmptyStatement;
+import com.hazelcast.topic.ITopic;
+import com.hazelcast.topic.MessageListener;
+import org.hibernate.cache.spi.CacheDataDescription;
+import org.hibernate.cache.spi.access.SoftLock;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Local only {@link RegionCache} implementation
+ * based on a topic to distribute cache updates.
+ */
+public class LocalRegionCache implements RegionCache {
+
+    private static final long SEC_TO_MS = 1000L;
+    private static final int MAX_SIZE = 100000;
+    private static final float BASE_EVICTION_RATE = 0.2F;
+
+    protected final HazelcastInstance hazelcastInstance;
+    protected final ITopic<Object> topic;
+    protected final MessageListener<Object> messageListener;
+    protected final ConcurrentMap<Object, Expirable> cache;
+    protected final Comparator versionComparator;
+    protected final AtomicLong markerIdCounter;
+    protected MapConfig config;
+
+    /**
+     * @param name              the name for this region cache, which is also used to retrieve configuration/topic
+     * @param hazelcastInstance the {@code HazelcastInstance} to which this region cache belongs, used to retrieve
+     *                          configuration and to lookup an {@link ITopic} to register a {@link MessageListener}
+     *                          with (optional)
+     * @param metadata          metadata describing the cached data, used to compare data versions (optional)
+     */
+    public LocalRegionCache(final String name, final HazelcastInstance hazelcastInstance,
+                            final CacheDataDescription metadata) {
+        this(name, hazelcastInstance, metadata, true);
+    }
+
+    /**
+     * @param name              the name for this region cache, which is also used to retrieve configuration/topic
+     * @param hazelcastInstance the {@code HazelcastInstance} to which this region cache belongs, used to retrieve
+     *                          configuration and to lookup an {@link ITopic} to register a {@link MessageListener}
+     *                          with if {@code withTopic} is {@code true} (optional)
+     * @param metadata          metadata describing the cached data, used to compare data versions (optional)
+     * @param withTopic         {@code true} to register a {@link MessageListener} with the {@link ITopic} whose name
+     *                          matches this region cache <i>if</i> a {@code HazelcastInstance} was provided to look
+     *                          up the topic; otherwise, {@code false} not to register a listener even if an instance
+     *                          was provided
+     */
+    public LocalRegionCache(final String name, final HazelcastInstance hazelcastInstance,
+                            final CacheDataDescription metadata, final boolean withTopic) {
+        this.hazelcastInstance = hazelcastInstance;
+        try {
+            config = hazelcastInstance != null ? hazelcastInstance.getConfig().findMapConfig(name) : null;
+        } catch (UnsupportedOperationException ignored) {
+            EmptyStatement.ignore(ignored);
+        }
+        versionComparator = metadata != null && metadata.isVersioned() ? metadata.getVersionComparator() : null;
+        cache = new ConcurrentHashMap<>();
+        markerIdCounter = new AtomicLong();
+
+        messageListener = createMessageListener();
+        if (withTopic && hazelcastInstance != null) {
+            topic = hazelcastInstance.getTopic(name);
+            topic.addMessageListener(messageListener);
+        } else {
+            topic = null;
+        }
+    }
+
+    @Override
+    public Object get(final Object key, long txTimestamp) {
+        final Expirable value = cache.get(key);
+        return value == null ? null : value.getValue(txTimestamp);
+    }
+
+    @Override
+    public boolean insert(final Object key, final Object value, final Object currentVersion) {
+        final Value newValue = new Value(currentVersion, nextTimestamp(), value);
+        return cache.putIfAbsent(key, newValue) == null;
+    }
+
+    @Override
+    public boolean put(final Object key, final Object value, final long txTimestamp, final Object version) {
+        while (true) {
+            Expirable previous = cache.get(key);
+            Value newValue = new Value(version, nextTimestamp(), value);
+            if (previous == null) {
+                if (cache.putIfAbsent(key, newValue) == null) {
+                    return true;
+                }
+            } else if (previous.isReplaceableBy(txTimestamp, version, versionComparator)) {
+                if (cache.replace(key, previous, newValue)) {
+                    return true;
+                }
+            } else {
+                return false;
+            }
+        }
+    }
+
+    @Override
+    public boolean update(final Object key, final Object newValue, final Object newVersion, final SoftLock softLock) {
+        boolean updated = false;
+        while (true) {
+            Expirable original = cache.get(key);
+            Expirable revised;
+            long timestamp = nextTimestamp();
+            if (original == null) {
+                // The entry must have expired. it should be safe to update
+                revised = new Value(newVersion, timestamp, newValue);
+                updated = true;
+                if (cache.putIfAbsent(key, revised) == null) {
+                    break;
+                }
+            } else {
+                if (softLock instanceof MarkerWrapper) {
+                    final ExpiryMarker unwrappedMarker = ((MarkerWrapper) softLock).getMarker();
+                    if (original.matches(unwrappedMarker)) {
+                        // The lock matches
+                        final ExpiryMarker marker = (ExpiryMarker) original;
+                        if (marker.isConcurrent()) {
+                            revised = marker.expire(timestamp);
+                            updated = false;
+                        } else {
+                            revised = new Value(newVersion, timestamp, newValue);
+                            updated = true;
+                        }
+                        if (cache.replace(key, original, revised)) {
+                            break;
+                        }
+                    } else if (original.getValue() == null) {
+                        // It's marked for expiration, leave it as is
+                        updated = false;
+                        break;
+                    } else {
+                        // It's a value. Instead of removing it, expire it to prevent stale from in progress
+                        // transactions being put in the cache
+                        revised = new ExpiryMarker(newVersion, timestamp, nextMarkerId()).expire(timestamp);
+                        updated = false;
+                        if (cache.replace(key, original, revised)) {
+                            break;
+                        }
+                    }
+                } else {
+                    break;
+                }
+            }
+        }
+        maybeNotifyTopic(key, newValue, newVersion);
+
+        return updated;
+    }
+
+    protected void maybeNotifyTopic(final Object key, final Object value, final Object version) {
+        if (topic != null) {
+            topic.publish(createMessage(key, value, version));
+        }
+    }
+
+    protected Object createMessage(final Object key, final Object value, final Object currentVersion) {
+        return new Invalidation(key, currentVersion);
+    }
+
+    protected MessageListener<Object> createMessageListener() {
+        return message -> maybeInvalidate(message.getMessageObject());
+    }
+
+    @Override
+    public boolean remove(final Object key) {
+        final Expirable value = cache.remove(key);
+        maybeNotifyTopic(key, null, (value == null) ? null : value.getVersion());
+        return (value != null);
+    }
+
+    @Override
+    public SoftLock tryLock(final Object key, final Object version) {
+        ExpiryMarker marker;
+        String markerId = nextMarkerId();
+        while (true) {
+            final Expirable original = cache.get(key);
+            long timeout = nextTimestamp() + CacheEnvironment.getDefaultCacheTimeoutInMillis();
+            if (original == null) {
+                marker = new ExpiryMarker(version, timeout, markerId);
+                if (cache.putIfAbsent(key, marker) == null) {
+                    break;
+                }
+            } else {
+                marker = original.markForExpiration(timeout, markerId);
+                if (cache.replace(key, original, marker)) {
+                    break;
+                }
+            }
+        }
+        return new MarkerWrapper(marker);
+    }
+
+    @Override
+    public void unlock(final Object key, final SoftLock lock) {
+        while (true) {
+            final Expirable original = cache.get(key);
+            if (original != null) {
+                if (!(lock instanceof MarkerWrapper)) {
+                    break;
+                }
+                final ExpiryMarker unwrappedMarker = ((MarkerWrapper) lock).getMarker();
+                if (original.matches(unwrappedMarker)) {
+                    final Expirable revised = ((ExpiryMarker) original).expire(nextTimestamp());
+                    if (cache.replace(key, original, revised)) {
+                        break;
+                    }
+                } else if (original.getValue() != null) {
+                    if (cache.remove(key, original)) {
+                        break;
+                    }
+                } else {
+                    break;
+                }
+            } else {
+                break;
+            }
+        }
+        maybeNotifyTopic(key, null, null);
+    }
+
+    @Override
+    public boolean contains(final Object key) {
+        return cache.containsKey(key);
+    }
+
+    @Override
+    public void clear() {
+        cache.clear();
+        maybeNotifyTopic(null, null, null);
+    }
+
+    @Override
+    public long size() {
+        return cache.size();
+    }
+
+    @Override
+    public long getSizeInMemory() {
+        return 0;
+    }
+
+    @Override
+    public Map asMap() {
+        return cache;
+    }
+
+    void cleanup() {
+        final int maxSize;
+        final long timeToLive;
+        if (config != null) {
+            maxSize = config.getEvictionConfig().getSize();
+            timeToLive = config.getTimeToLiveSeconds() * SEC_TO_MS;
+        } else {
+            maxSize = MAX_SIZE;
+            timeToLive = CacheEnvironment.getDefaultCacheTimeoutInMillis();
+        }
+
+        boolean limitSize = maxSize > 0 && maxSize != Integer.MAX_VALUE;
+        if (limitSize || timeToLive > 0) {
+            List<EvictionEntry> entries = searchEvictableEntries(timeToLive, limitSize);
+            final int diff = cache.size() - maxSize;
+            final int evictionRate = calculateEvictionRate(diff, maxSize);
+            if (evictionRate > 0 && entries != null) {
+                evictEntries(entries, evictionRate);
+            }
+        }
+    }
+
+    protected void maybeInvalidate(final Object messageObject) {
+        Invalidation invalidation = (Invalidation) messageObject;
+        Object key = invalidation.getKey();
+        if (key == null) {
+            // Invalidate the entire region cache.
+            cache.clear();
+        } else if (versionComparator == null) {
+            // For an unversioned entity or collection we can only invalidate the entry.
+            cache.remove(key);
+        } else {
+            // For versioned entities we can avoid the invalidation if both we and the remote node know the version,
+            // AND our version is definitely equal or higher.  Otherwise, we have to just invalidate our entry.
+            final Expirable value = cache.get(key);
+            if (value != null) {
+                maybeInvalidateVersionedEntity(key, value, invalidation.getVersion());
+            }
+        }
+    }
+
+    private void maybeInvalidateVersionedEntity(final Object key, final Expirable value, final Object newVersion) {
+        if (newVersion == null) {
+            // This invalidation was for an entity with unknown version.  Just invalidate the entry
+            // unconditionally.
+            cache.remove(key);
+        } else {
+            // Invalidate our entry only if it was of a lower version.
+            Object currentVersion = value.getVersion();
+            if (versionComparator.compare(currentVersion, newVersion) < 0) {
+                cache.remove(key, value);
+            }
+        }
+    }
+
+    private String nextMarkerId() {
+        return Long.toString(markerIdCounter.getAndIncrement());
+    }
+
+    protected long nextTimestamp() {
+        return hazelcastInstance == null ? Clock.currentTimeMillis()
+          : HazelcastTimestamper.nextTimestamp(hazelcastInstance);
+    }
+
+    private List<EvictionEntry> searchEvictableEntries(final long timeToLive, final boolean limitSize) {
+        List<EvictionEntry> entries = null;
+        Iterator<Entry<Object, Expirable>> iter = cache.entrySet().iterator();
+        long now = nextTimestamp();
+        while (iter.hasNext()) {
+            final Entry<Object, Expirable> e = iter.next();
+            final Object k = e.getKey();
+            final Expirable expirable = e.getValue();
+            if (expirable instanceof ExpiryMarker) {
+                continue;
+            }
+            final Value v = (Value) expirable;
+            if (timeToLive > 0 && v.getTimestamp() + timeToLive < now) {
+                iter.remove();
+            } else if (limitSize) {
+                if (entries == null) {
+                    // Use a List rather than a Set for correctness. Using a Set, especially a TreeSet
+                    // based on EvictionEntry.compareTo, causes evictions to be processed incorrectly
+                    // when two or more entries in the map have the same timestamp. In such a case, the
+                    // _first_ entry at a given timestamp is the only one that can be evicted because
+                    // TreeSet does not add "equivalent" entries. A second benefit of using a List is
+                    // that the cost of sorting the entries is not incurred if eviction isn't performed
+                    entries = new ArrayList<>(cache.size());
+                }
+                entries.add(new EvictionEntry(k, v));
+            }
+        }
+        return entries;
+    }
+
+    private int calculateEvictionRate(final int diff, final int maxSize) {
+        return diff >= 0 ? (diff + (int) (maxSize * BASE_EVICTION_RATE)) : 0;
+    }
+
+    private void evictEntries(final List<EvictionEntry> entries, final int evictionRate) {
+        // Only sort the entries if we're going to evict some
+        Collections.sort(entries);
+        int removed = 0;
+        for (EvictionEntry entry : entries) {
+            if (cache.remove(entry.key, entry.value) && ++removed == evictionRate) {
+                break;
+            }
+        }
+    }
+
+    /**
+     * Inner class that instances represent an entry marked for eviction
+     */
+    private static final class EvictionEntry implements Comparable<EvictionEntry> {
+        final Object key;
+        final Value value;
+
+        private EvictionEntry(final Object key, final Value value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        @Override
+        public int compareTo(final EvictionEntry o) {
+            final long thisVal = this.value.getTimestamp();
+            final long anotherVal = o.value.getTimestamp();
+            return (Long.compare(thisVal, anotherVal));
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            EvictionEntry that = (EvictionEntry) o;
+
+            return (Objects.equals(key, that.key))
+              && (Objects.equals(value, that.value));
+        }
+
+        @Override
+        public int hashCode() {
+            return key == null ? 0 : key.hashCode();
+        }
+    }
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/local/Timestamp.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/local/Timestamp.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.local;
+
+import com.hazelcast.hibernate.serialization.HibernateDataSerializerHook;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
+
+/**
+ * Hazelcast compatible implementation of a timestamp for internal eviction
+ */
+public class Timestamp implements IdentifiedDataSerializable {
+
+    private Object key;
+    private long timestamp;
+
+    public Timestamp() {
+    }
+
+    public Timestamp(final Object key, final long timestamp) {
+        this.key = key;
+        this.timestamp = timestamp;
+    }
+
+    public Object getKey() {
+        return key;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    @Override
+    public void writeData(final ObjectDataOutput out) throws IOException {
+        out.writeObject(key);
+        out.writeLong(timestamp);
+    }
+
+    @Override
+    public void readData(final ObjectDataInput in) throws IOException {
+        key = in.readObject();
+        timestamp = in.readLong();
+    }
+
+    @Override
+    public int getFactoryId() {
+        return HibernateDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return HibernateDataSerializerHook.TIMESTAMP;
+    }
+
+    @Override
+    public String toString() {
+        return "Timestamp" + "{key=" + key + ", timestamp=" + timestamp + '}';
+    }
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/local/TimestampsRegionCache.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/local/TimestampsRegionCache.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.local;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.RegionCache;
+import com.hazelcast.hibernate.serialization.Expirable;
+import com.hazelcast.hibernate.serialization.Value;
+
+/**
+ * A timestamp based local RegionCache
+ */
+public class TimestampsRegionCache extends LocalRegionCache implements RegionCache {
+
+    public TimestampsRegionCache(final String name, final HazelcastInstance hazelcastInstance) {
+        super(name, hazelcastInstance, null);
+    }
+
+    @Override
+    public boolean put(final Object key, final Object value, final long txTimestamp, final Object version) {
+        // use the value in txTimestamp as the timestamp instead of the value, since
+        // hibernate pre-invalidates with a large value, and then invalidates with
+        //the actual time, which can cause queries to not be cached.
+        boolean succeed = super.put(key, value, txTimestamp, version);
+        if (succeed) {
+            maybeNotifyTopic(key, value, version);
+        }
+        return succeed;
+    }
+
+    @Override
+    protected void maybeInvalidate(final Object messageObject) {
+        final Timestamp ts = (Timestamp) messageObject;
+        final Object key = ts.getKey();
+
+        if (key == null) {
+            // Invalidate the entire region cache.
+            cache.clear();
+            return;
+        }
+
+        for (; ; ) {
+            final Expirable value = cache.get(key);
+            final Long current = value != null ? (Long) value.getValue() : null;
+            if (current != null) {
+                if (ts.getTimestamp() > current) {
+                    if (cache.replace(key, value, new Value(value.getVersion(), nextTimestamp(), ts.getTimestamp()))) {
+                        return;
+                    }
+                } else {
+                    return;
+                }
+            } else {
+                if (cache.putIfAbsent(key, new Value(null, nextTimestamp(), ts.getTimestamp())) == null) {
+                    return;
+                }
+            }
+        }
+    }
+
+    @Override
+    protected Object createMessage(final Object key, final Object value, final Object currentVersion) {
+        return new Timestamp(key, (Long) value);
+    }
+
+    @Override
+    public void clear() {
+        cache.clear();
+        maybeNotifyTopic(null, -1L, null);
+    }
+
+    @Override
+    final void cleanup() {
+    }
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/local/package-info.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/local/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+/**
+ * Provides local classes for Hibernate.
+ * such as TimeStamp,CleanupService.
+ */
+package com.hazelcast.hibernate.local;

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/package-info.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+/**
+ * Contains interfaces/classes related to Hibernate.
+ */
+package com.hazelcast.hibernate;

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/region/AbstractGeneralRegion.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/region/AbstractGeneralRegion.java
@@ -78,7 +78,6 @@ abstract class AbstractGeneralRegion<Cache extends RegionCache>
         }
     }
 
-    @Override
     public Cache getCache() {
         return cache;
     }

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/region/AbstractHazelcastRegion.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/region/AbstractHazelcastRegion.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.region;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.HazelcastTimestamper;
+import com.hazelcast.hibernate.RegionCache;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import org.hibernate.cache.CacheException;
+
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Abstract superclass of Hazelcast region of Hibernate caches
+ *
+ * @param <Cache> implementation type of RegionCache
+ */
+abstract class AbstractHazelcastRegion<Cache extends RegionCache> implements HazelcastRegion<Cache> {
+
+    protected final Properties props;
+    private final HazelcastInstance instance;
+    private final String regionName;
+    private final int timeout;
+
+    protected AbstractHazelcastRegion(final HazelcastInstance instance, final String regionName, final Properties props) {
+        this.instance = instance;
+        this.regionName = regionName;
+        this.timeout = HazelcastTimestamper.getTimeout(instance, regionName);
+        this.props = props;
+    }
+
+    public void destroy() throws CacheException {
+        // Destroy of the region should not propagate
+        // to other nodes of cluster.
+        // Do nothing on destroy.
+    }
+
+    /**
+     * @return The size of the internal <code>{@link com.hazelcast.map.IMap}</code>.
+     */
+    public long getElementCountInMemory() {
+        return getCache().size();
+    }
+
+    /**
+     * Hazelcast does not support pushing elements to disk.
+     *
+     * @return -1 this value means "unsupported"
+     */
+    @Override
+    public long getElementCountOnDisk() {
+        return -1;
+    }
+
+    /**
+     * @return The name of the region.
+     */
+    @Override
+    public String getName() {
+        return regionName;
+    }
+
+    /**
+     * @return a rough estimate of number of bytes used by this region.
+     */
+    @Override
+    public long getSizeInMemory() {
+        return getCache().getSizeInMemory();
+    }
+
+    @Override
+    public final int getTimeout() {
+        return timeout;
+    }
+
+    @Override
+    public final long nextTimestamp() {
+        return HazelcastTimestamper.nextTimestamp(instance);
+    }
+
+    /**
+     * Appears to be used only by <code>org.hibernate.stat.SecondLevelCacheStatistics</code>.
+     *
+     * @return the internal <code>IMap</code> used for this region.
+     */
+    @Override
+    public Map toMap() {
+        return getCache().asMap();
+    }
+
+    @Override
+    public boolean contains(final Object key) {
+        return getCache().contains(key);
+    }
+
+    @Override
+    public final HazelcastInstance getInstance() {
+        return instance;
+    }
+
+    @Override
+    public final ILogger getLogger() {
+        final String name = getClass().getName();
+        try {
+            return instance.getLoggingService().getLogger(name);
+        } catch (UnsupportedOperationException e) {
+            // HazelcastInstance is instance of HazelcastClient.
+            return Logger.getLogger(name);
+        }
+    }
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/region/AbstractTransactionalDataRegion.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/region/AbstractTransactionalDataRegion.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.region;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.RegionCache;
+import org.hibernate.cache.spi.CacheDataDescription;
+import org.hibernate.cache.spi.TransactionalDataRegion;
+
+import java.util.Properties;
+
+/**
+ * Abstract base class of all regions
+ *
+ * @param <Cache> implementation type of RegionCache
+ */
+public abstract class AbstractTransactionalDataRegion<Cache extends RegionCache>
+        extends AbstractHazelcastRegion<Cache>
+        implements TransactionalDataRegion {
+
+    private final CacheDataDescription metadata;
+    private final Cache cache;
+
+    protected AbstractTransactionalDataRegion(final HazelcastInstance instance, final String regionName,
+                                              final Properties props, final CacheDataDescription metadata,
+                                              final Cache cache) {
+        super(instance, regionName, props);
+        this.metadata = metadata;
+        this.cache = cache;
+    }
+
+    @Override
+    public CacheDataDescription getCacheDataDescription() {
+        return metadata;
+    }
+
+    @Override
+    public boolean isTransactionAware() {
+        return false;
+    }
+
+    @Override
+    public Cache getCache() {
+        return cache;
+    }
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/region/CacheKeyImpl.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/region/CacheKeyImpl.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.region;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.DataSerializable;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.type.Type;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Cache key implementation
+ */
+public final class CacheKeyImpl implements DataSerializable {
+
+  private Object id;
+  private Type type;
+  private String entityOrRoleName;
+  private String tenantId;
+  private int hashCode;
+
+  public CacheKeyImpl() {
+  }
+
+  /**
+   * Construct a new key for a collection or entity instance.
+   * Note that an entity name should always be the root entity
+   * name, not a subclass entity name.
+   *
+   * @param id The identifier associated with the cached data
+   * @param type The Hibernate type mapping
+   * @param entityOrRoleName The entity or collection-role name.
+   * @param tenantId The tenant identifier associated this data.
+   */
+  public CacheKeyImpl(
+      final Object id,
+      final Type type,
+      final String entityOrRoleName,
+      final String tenantId,
+      final SessionFactoryImplementor factory) {
+    this.id = id;
+    this.type = type;
+    this.entityOrRoleName = entityOrRoleName;
+    this.tenantId = tenantId;
+    this.hashCode = calculateHashCode(type, factory);
+  }
+
+  @SuppressWarnings("checkstyle:magicnumber")
+  private int calculateHashCode(Type type, SessionFactoryImplementor factory) {
+    int result = type.getHashCode(id, factory);
+    result = 31 * result + (tenantId != null ? tenantId.hashCode() : 0);
+    return result;
+  }
+
+  Object getId() {
+    return id;
+  }
+
+  @Override
+  public void writeData(ObjectDataOutput out) throws IOException {
+    out.writeObject(id);
+    out.writeUTF(entityOrRoleName);
+    out.writeUTF(tenantId);
+    out.writeObject(type);
+    out.writeInt(hashCode);
+  }
+
+  @Override
+  public void readData(ObjectDataInput in) throws IOException {
+    id = in.readObject();
+    entityOrRoleName = in.readUTF();
+    tenantId = in.readUTF();
+    type = in.readObject();
+    hashCode = in.readInt();
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+
+    final CacheKeyImpl that = (CacheKeyImpl) other;
+    if (!type.isEqual(id, that.id)) {
+      return false;
+    }
+    if (!entityOrRoleName.equals(that.entityOrRoleName)) {
+      return false;
+    }
+
+    return Objects.equals(tenantId, that.tenantId);
+  }
+
+  @Override
+  public int hashCode() {
+    return hashCode;
+  }
+
+  @Override
+  public String toString() {
+    // Used to be required for OSCache
+    return entityOrRoleName + '#' + id.toString();
+  }
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/region/HazelcastCollectionRegion.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/region/HazelcastCollectionRegion.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.region;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.RegionCache;
+import com.hazelcast.hibernate.access.NonStrictReadWriteAccessDelegate;
+import com.hazelcast.hibernate.access.ReadOnlyAccessDelegate;
+import com.hazelcast.hibernate.access.ReadWriteAccessDelegate;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.CacheDataDescription;
+import org.hibernate.cache.spi.CollectionRegion;
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cache.spi.access.CollectionRegionAccessStrategy;
+
+import java.util.Properties;
+
+/**
+ * An collection region implementation based upon Hazelcast IMap with basic concurrency / transactional support
+ * by supplying CollectionRegionAccessStrategy
+ *
+ * @param <Cache> implementation type of RegionCache
+ */
+public final class HazelcastCollectionRegion<Cache extends RegionCache> extends AbstractTransactionalDataRegion<Cache>
+        implements CollectionRegion {
+
+    public HazelcastCollectionRegion(final HazelcastInstance instance,
+                                     final String regionName, final Properties props,
+                                     final CacheDataDescription metadata, final Cache cache) {
+        super(instance, regionName, props, metadata, cache);
+    }
+
+    @Override
+    public CollectionRegionAccessStrategy buildAccessStrategy(final AccessType accessType) throws CacheException {
+        if (AccessType.READ_ONLY.equals(accessType)) {
+            return new CollectionRegionAccessStrategyAdapter(
+                    new ReadOnlyAccessDelegate<HazelcastCollectionRegion>(this, props));
+        }
+        if (AccessType.NONSTRICT_READ_WRITE.equals(accessType)) {
+            return new CollectionRegionAccessStrategyAdapter(
+                    new NonStrictReadWriteAccessDelegate<HazelcastCollectionRegion>(this, props));
+        }
+        if (AccessType.READ_WRITE.equals(accessType)) {
+            return new CollectionRegionAccessStrategyAdapter(
+                    new ReadWriteAccessDelegate<HazelcastCollectionRegion>(this, props));
+        }
+        throw new CacheException("AccessType \"" + accessType + "\" is not currently supported by Hazelcast.");
+    }
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/region/HazelcastEntityRegion.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/region/HazelcastEntityRegion.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.region;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.RegionCache;
+import com.hazelcast.hibernate.access.NonStrictReadWriteAccessDelegate;
+import com.hazelcast.hibernate.access.ReadOnlyAccessDelegate;
+import com.hazelcast.hibernate.access.ReadWriteAccessDelegate;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.CacheDataDescription;
+import org.hibernate.cache.spi.EntityRegion;
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
+
+import java.util.Properties;
+
+/**
+ * An entity region implementation based upon Hazelcast IMap with basic concurrency / transactional support
+ * by supplying EntityRegionAccessStrategy
+ *
+ * @param <Cache> implementation type of RegionCache
+ */
+public final class HazelcastEntityRegion<Cache extends RegionCache>
+        extends AbstractTransactionalDataRegion<Cache> implements EntityRegion {
+
+    public HazelcastEntityRegion(final HazelcastInstance instance,
+                                 final String regionName, final Properties props,
+                                 final CacheDataDescription metadata, final Cache cache) {
+        super(instance, regionName, props, metadata, cache);
+    }
+
+    @Override
+    public EntityRegionAccessStrategy buildAccessStrategy(final AccessType accessType) throws CacheException {
+        if (AccessType.READ_ONLY.equals(accessType)) {
+            return new EntityRegionAccessStrategyAdapter(
+                    new ReadOnlyAccessDelegate<HazelcastEntityRegion>(this, props));
+        }
+        if (AccessType.NONSTRICT_READ_WRITE.equals(accessType)) {
+            return new EntityRegionAccessStrategyAdapter(
+                    new NonStrictReadWriteAccessDelegate<HazelcastEntityRegion>(this, props));
+        }
+        if (AccessType.READ_WRITE.equals(accessType)) {
+            return new EntityRegionAccessStrategyAdapter(
+                    new ReadWriteAccessDelegate<HazelcastEntityRegion>(this, props));
+        }
+        throw new CacheException("AccessType \"" + accessType + "\" is not currently supported by Hazelcast.");
+    }
+
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/region/HazelcastNaturalIdRegion.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/region/HazelcastNaturalIdRegion.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.region;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.RegionCache;
+import com.hazelcast.hibernate.access.NonStrictReadWriteAccessDelegate;
+import com.hazelcast.hibernate.access.ReadOnlyAccessDelegate;
+import com.hazelcast.hibernate.access.ReadWriteAccessDelegate;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.CacheDataDescription;
+import org.hibernate.cache.spi.NaturalIdRegion;
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cache.spi.access.NaturalIdRegionAccessStrategy;
+
+import java.util.Properties;
+
+/**
+ * The type Hazelcast natural id region.
+ *
+ * @param <Cache> NaturalIdRegionCache
+ */
+public class HazelcastNaturalIdRegion<Cache extends RegionCache>
+        extends AbstractTransactionalDataRegion<Cache>
+        implements NaturalIdRegion {
+
+    /**
+     * Instantiates a new Hazelcast natural id region.
+     *
+     * @param instance   the instance
+     * @param regionName the region name
+     * @param props      the props
+     * @param metadata   the metadata
+     * @param cache      the cache
+     */
+    public HazelcastNaturalIdRegion(final HazelcastInstance instance, final String regionName,
+                                    final Properties props, final CacheDataDescription metadata,
+                                    final Cache cache) {
+        super(instance, regionName, props, metadata, cache);
+    }
+
+    @Override
+    public NaturalIdRegionAccessStrategy buildAccessStrategy(final AccessType accessType) throws CacheException {
+        if (AccessType.READ_ONLY.equals(accessType)) {
+            return new NaturalIdRegionAccessStrategyAdapter(
+                    new ReadOnlyAccessDelegate<HazelcastNaturalIdRegion>(this, props));
+        }
+        if (AccessType.NONSTRICT_READ_WRITE.equals(accessType)) {
+            return new NaturalIdRegionAccessStrategyAdapter(
+                    new NonStrictReadWriteAccessDelegate<HazelcastNaturalIdRegion>(this, props));
+        }
+        if (AccessType.READ_WRITE.equals(accessType)) {
+            return new NaturalIdRegionAccessStrategyAdapter(
+                    new ReadWriteAccessDelegate<HazelcastNaturalIdRegion>(this, props));
+        }
+        throw new CacheException("AccessType \"" + accessType + "\" is not currently supported by Hazelcast.");
+    }
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/region/HazelcastQueryResultsRegion.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/region/HazelcastQueryResultsRegion.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.region;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.local.LocalRegionCache;
+import org.hibernate.cache.spi.QueryResultsRegion;
+
+import java.util.Properties;
+
+/**
+ * Hazelcast based implementation of a storage region for query results
+ */
+public class HazelcastQueryResultsRegion extends AbstractGeneralRegion<LocalRegionCache> implements QueryResultsRegion {
+
+    public HazelcastQueryResultsRegion(final HazelcastInstance instance, final String name, final Properties props) {
+        // Note: The HazelcastInstance _must_ be passed down here. Otherwise query caches
+        // cannot be configured and will always use defaults. However, even though we're
+        // passing the HazelcastInstance, we don't want to use an ITopic for invalidation
+        // because the timestamps cache can take care of outdated queries
+        super(instance, name, props, new LocalRegionCache(name, instance, null, false));
+    }
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/region/HazelcastRegion.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/region/HazelcastRegion.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.region;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.RegionCache;
+import com.hazelcast.logging.ILogger;
+import org.hibernate.cache.spi.Region;
+
+/**
+ * Hazelcast specific interface version of Hibernate's Region
+ *
+ * @param <Cache> implementation type of RegionCache
+ */
+public interface HazelcastRegion<Cache extends RegionCache> extends Region {
+
+    HazelcastInstance getInstance();
+
+    Cache getCache();
+
+    ILogger getLogger();
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/region/HazelcastTimestampsRegion.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/region/HazelcastTimestampsRegion.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.region;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.RegionCache;
+import org.hibernate.cache.spi.TimestampsRegion;
+
+import java.util.Properties;
+
+/**
+ * Hazelcast based timestamp using region implementation
+ *
+ * @param <Cache> implementation type of RegionCache
+ */
+public class HazelcastTimestampsRegion<Cache extends RegionCache>
+        extends AbstractGeneralRegion<Cache> implements TimestampsRegion {
+
+    public HazelcastTimestampsRegion(final HazelcastInstance instance, final String name,
+                                     final Properties props, final Cache cache) {
+        super(instance, name, props, cache);
+    }
+
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/region/NaturalIdCacheKey.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/region/NaturalIdCacheKey.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.region;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.DataSerializable;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.internal.util.ValueHolder;
+import org.hibernate.internal.util.compare.EqualsHelper;
+import org.hibernate.type.EntityType;
+import org.hibernate.type.Type;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Arrays;
+
+/**
+ * Cache key implementation for natural ID
+ */
+public final class NaturalIdCacheKey implements DataSerializable {
+
+  private Serializable[] naturalIdValues;
+  private String entityName;
+  private String tenantId;
+  private int hashCode;
+  private transient ValueHolder<String> toString;
+
+  public NaturalIdCacheKey() {
+  }
+
+  /**
+   * Construct a new key for a caching natural identifier resolutions into the second level cache.
+   * @param naturalIdValues The naturalIdValues associated with the cached data
+   * @param propertyTypes
+   * @param naturalIdPropertyIndexes
+   * @param session The originating session
+   */
+  @SuppressWarnings("checkstyle:magicnumber")
+  public NaturalIdCacheKey(
+      final Object[] naturalIdValues,
+      Type[] propertyTypes, int[] naturalIdPropertyIndexes, final String entityName,
+      final SessionImplementor session) {
+
+    this.naturalIdValues = new Serializable[naturalIdValues.length];
+    this.entityName = entityName;
+    this.tenantId = session.getTenantIdentifier();
+
+    final SessionFactoryImplementor factory = session.getFactory();
+
+    int result = 1;
+    result = 31 * result + (this.entityName == null ? 0 : this.entityName.hashCode());
+    result = 31 * result + (this.tenantId == null ? 0 : this.tenantId.hashCode());
+
+    for (int i = 0; i < naturalIdValues.length; i++) {
+      final int naturalIdPropertyIndex = naturalIdPropertyIndexes[i];
+      final Type type = propertyTypes[naturalIdPropertyIndex];
+      final Object value = naturalIdValues[i];
+
+      result = 31 * result + (value != null ? type.getHashCode(value, factory) : 0);
+
+      if (type instanceof EntityType && type.getSemiResolvedType(factory).getReturnedClass().isInstance(value)) {
+        this.naturalIdValues[i] = (Serializable) value;
+      } else {
+        this.naturalIdValues[i] = type.disassemble(value, session, null);
+      }
+    }
+
+    this.hashCode = result;
+    initTransients();
+  }
+
+  private void initTransients() {
+    this.toString = new ValueHolder<>(
+      () -> {
+        //Complex toString is needed as naturalIds for entities are not simply based on a single value like primary keys
+        //the only same way to differentiate the keys is to included the disassembled values in the string.
+        final StringBuilder toStringBuilder = new StringBuilder().append(entityName).append("##NaturalId[");
+        for (int i = 0; i < naturalIdValues.length; i++) {
+          toStringBuilder.append(naturalIdValues[i]);
+          if (i + 1 < naturalIdValues.length) {
+            toStringBuilder.append(", ");
+          }
+        }
+        toStringBuilder.append("]");
+
+        return toStringBuilder.toString();
+      }
+    );
+  }
+
+  Serializable[] getNaturalIdValues() {
+    return naturalIdValues;
+  }
+
+  @Override
+  public void writeData(ObjectDataOutput out) throws IOException {
+    out.writeInt(naturalIdValues.length);
+    for (Serializable naturalIdValue : naturalIdValues) {
+      out.writeObject(naturalIdValue);
+    }
+    out.writeUTF(entityName);
+    out.writeUTF(tenantId);
+    out.writeInt(hashCode);
+  }
+
+  @Override
+  public void readData(ObjectDataInput in) throws IOException {
+    int length = in.readInt();
+    naturalIdValues = new Serializable[length];
+    for (int i = 0; i < length; i++) {
+      naturalIdValues[i] = in.readObject();
+    }
+    entityName = in.readUTF();
+    tenantId = in.readUTF();
+    hashCode = in.readInt();
+
+    initTransients();
+  }
+
+  @Override
+  public String toString() {
+    return toString.getValue();
+  }
+
+  @Override
+  public int hashCode() {
+    return this.hashCode;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null) {
+      return false;
+    }
+    if (this == o) {
+      return true;
+    }
+
+    if (hashCode != o.hashCode() || !(o instanceof NaturalIdCacheKey)) {
+      //hashCode is part of this check since it is pre-calculated and hash must match for equals to be true
+      return false;
+    }
+
+    final NaturalIdCacheKey other = (NaturalIdCacheKey) o;
+    return EqualsHelper.equals(entityName, other.entityName)
+        && EqualsHelper.equals(tenantId, other.tenantId)
+        && Arrays.deepEquals(this.naturalIdValues, other.naturalIdValues);
+  }
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/serialization/Expirable.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/serialization/Expirable.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.serialization;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
+import java.util.Comparator;
+
+/**
+ * A container class which represents an entry in a region cache which can be marked for expiration
+ */
+public abstract class Expirable implements IdentifiedDataSerializable {
+
+    protected Object version;
+
+    protected Expirable() {
+    }
+
+    protected Expirable(final Object version) {
+        this.version = version;
+    }
+
+    /**
+     * Determine if the current entry can be overridden with a value corresponding to the given new version
+     * and the transaction timestamp.
+     *
+     * @param txTimestamp       the timestamp of the transaction
+     * @param newVersion        the new version for the replacement value
+     * @param versionComparator the comparator to use for the version
+     * @return {@code true} if the value can be replaced, {@code false} otherwise
+     */
+    public abstract boolean isReplaceableBy(final long txTimestamp, final Object newVersion,
+                                            final Comparator versionComparator);
+
+    /**
+     * @return the value contained, or {@code null} if none exists
+     */
+    public abstract Object getValue();
+
+    /**
+     * @param txTimestamp the timestamp of the transaction
+     * @return the value contained if it was created before the transaction timestamp or {@code null}
+     */
+    public abstract Object getValue(final long txTimestamp);
+
+    /**
+     * @return the version representing the value of {@code null} if the entry is not versioned
+     */
+    public Object getVersion() {
+        return version;
+    }
+
+    /**
+     * @return {@code true} if the {@link Expirable} matches using the specified lock, {@code false} otherwise
+     * @see ExpiryMarker#expire(long)
+     */
+    public abstract boolean matches(final ExpiryMarker lock);
+
+    /**
+     * Mark the entry for expiration with the given timeout and marker id.
+     * <p/>
+     * For every invocation a corresponding call to {@link ExpiryMarker#expire(long)} should be made, provided that
+     * the returned marker {@link #matches(ExpiryMarker)}
+     *
+     * @param timeout      the timestamp in which the lock times out
+     * @param nextMarkerId the next lock id to use if creating a new lock
+     * @return the newly created marker, or the current marker with a higher multiplicity
+     * @see ExpiryMarker#expire(long)
+     */
+    public abstract ExpiryMarker markForExpiration(final long timeout, final String nextMarkerId);
+
+    @Override
+    public void writeData(final ObjectDataOutput out) throws IOException {
+        out.writeObject(version);
+    }
+
+    @Override
+    public void readData(final ObjectDataInput in) throws IOException {
+        version = in.readObject();
+    }
+
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/serialization/ExpiryMarker.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/serialization/ExpiryMarker.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.serialization;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Comparator;
+
+/**
+ * An entry which is marked for expiration. This can occur when Hibernate is expecting to update an entry as a result
+ * of changes being made in an in-progress transaction
+ * <p/>
+ * Such an entry has the following properties
+ * <ul>
+ *     <li>It will always return a null value, resulting in a cache miss</li>
+ *     <li>It is only replaceable when it is completely expired</li>
+ *     <li>It can be marked by multiple transactions at the same time and will not expire until all transactions complete</li>
+ *     <li>It should not be expired unless {@link #matches(ExpiryMarker)} is true</li>
+ * </ul>
+ */
+public class ExpiryMarker extends Expirable implements Serializable {
+
+    private static final long NOT_COMPLETELY_EXPIRED = -1;
+    private boolean concurrent;
+    private long expiredTimestamp;
+    private String markerId;
+    private int multiplicity;
+    private long timeout;
+
+    public ExpiryMarker() {
+    }
+
+    public ExpiryMarker(final Object version, final long timeout, final String markerId) {
+        this(version, false, NOT_COMPLETELY_EXPIRED, markerId, 1, timeout);
+    }
+
+    private ExpiryMarker(final Object version, final boolean concurrent, final long expiredTimestamp,
+                         final String markerId, final int multiplicity, final long timeout) {
+        super(version);
+        this.concurrent = concurrent;
+        this.expiredTimestamp = expiredTimestamp;
+        this.markerId = markerId;
+        this.multiplicity = multiplicity;
+        this.timeout = timeout;
+    }
+
+    @Override
+    public boolean isReplaceableBy(final long txTimestamp, final Object newVersion,
+                                   final Comparator versionComparator) {
+        // If the marker has timed out it should be fine to write to write to it
+        if (txTimestamp > timeout) {
+            return true;
+        }
+
+        // If the marker is still marked, it is definitely not replaceable
+        if (multiplicity > 0) {
+            return false;
+        }
+
+        if (version == null) {
+            // If the marker was expired in the past, its good to write to
+            return expiredTimestamp != NOT_COMPLETELY_EXPIRED && txTimestamp > expiredTimestamp;
+        }
+
+        //noinspection unchecked
+        return versionComparator.compare(version, newVersion) < 0;
+    }
+
+    @Override
+    public Object getValue() {
+        return null;
+    }
+
+    @Override
+    public Object getValue(final long txTimestamp) {
+        return null;
+    }
+
+    @Override
+    public boolean matches(final ExpiryMarker lock) {
+        return markerId.equals(lock.markerId);
+    }
+
+    /**
+     * @return {@code true} if the marker has ever been {@link #markForExpiration(long, String)}
+     *         concurrently, {@code false} otherwise
+     */
+    public boolean isConcurrent() {
+        return concurrent;
+    }
+
+    @Override
+    public ExpiryMarker markForExpiration(final long timeout, final String nextMarkerId) {
+        return new ExpiryMarker(version, true, NOT_COMPLETELY_EXPIRED, markerId, multiplicity + 1, timeout);
+    }
+
+    /**
+     * Expire the marker. The marker may have been marked multiple times so it may still not
+     * be {@link #isReplaceableBy(long, Object, Comparator) replaceable}.
+     *
+     * @param timestamp the timestamp to specify when it was completely expired
+     * @return a new {@link ExpiryMarker}
+     */
+    public ExpiryMarker expire(final long timestamp) {
+        int newMultiplicity = multiplicity - 1;
+        long newExpiredTimestamp = newMultiplicity == 0 ? timestamp : expiredTimestamp;
+
+        return new ExpiryMarker(version, concurrent, newExpiredTimestamp, markerId, newMultiplicity, timeout);
+    }
+
+    @Override
+    public void writeData(final ObjectDataOutput out) throws IOException {
+        super.writeData(out);
+        out.writeBoolean(concurrent);
+        out.writeUTF(markerId);
+        out.writeInt(multiplicity);
+        out.writeLong(timeout);
+        out.writeLong(expiredTimestamp);
+    }
+
+    @Override
+    public void readData(final ObjectDataInput in) throws IOException {
+        super.readData(in);
+        concurrent = in.readBoolean();
+        markerId = in.readUTF();
+        multiplicity = in.readInt();
+        timeout = in.readLong();
+        expiredTimestamp = in.readLong();
+    }
+
+    @Override
+    public int getFactoryId() {
+        return HibernateDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return HibernateDataSerializerHook.EXPIRY_MARKER;
+    }
+
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/serialization/HibernateDataSerializerHook.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/serialization/HibernateDataSerializerHook.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.serialization;
+
+import com.hazelcast.hibernate.distributed.LockEntryProcessor;
+import com.hazelcast.hibernate.distributed.UnlockEntryProcessor;
+import com.hazelcast.hibernate.distributed.UpdateEntryProcessor;
+import com.hazelcast.hibernate.local.Invalidation;
+import com.hazelcast.hibernate.local.Timestamp;
+import com.hazelcast.internal.serialization.DataSerializerHook;
+import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
+import com.hazelcast.nio.serialization.DataSerializableFactory;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+/**
+ * An implementation of {@link DataSerializerHook} which constructs any of the
+ * {@link com.hazelcast.nio.serialization.DataSerializable} objects for the
+ * hibernate module
+ */
+public class HibernateDataSerializerHook implements DataSerializerHook {
+
+    /**
+     * The factory id for this class
+     */
+    public static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.HIBERNATE_DS_FACTORY, F_ID_OFFSET_HIBERNATE);
+    /**
+     * @see Value
+     */
+    public static final int VALUE = 0;
+    /**
+     * @see ExpiryMarker
+     */
+    public static final int EXPIRY_MARKER = 1;
+    /**
+     * @see LockEntryProcessor
+     */
+    public static final int LOCK = 2;
+    /**
+     * @see UnlockEntryProcessor
+     */
+    public static final int UNLOCK = 3;
+    /**
+     * @see UpdateEntryProcessor
+     */
+    public static final int UPDATE = 4;
+    /**
+     * @see Invalidation
+     */
+    public static final int INVALIDATION = 5;
+    /**
+     * @see Timestamp
+     */
+    public static final int TIMESTAMP = 6;
+
+    @Override
+    public int getFactoryId() {
+        return F_ID;
+    }
+
+    @Override
+    public DataSerializableFactory createFactory() {
+        return new Factory();
+    }
+
+    private static class Factory implements DataSerializableFactory {
+        @Override
+        public IdentifiedDataSerializable create(final int typeId) {
+            IdentifiedDataSerializable result;
+            switch (typeId) {
+                case VALUE:
+                    result = new Value();
+                    break;
+                case EXPIRY_MARKER:
+                    result = new ExpiryMarker();
+                    break;
+                case LOCK:
+                    result = new LockEntryProcessor();
+                    break;
+                case UNLOCK:
+                    result = new UnlockEntryProcessor();
+                    break;
+                case UPDATE:
+                    result = new UpdateEntryProcessor();
+                    break;
+                case INVALIDATION:
+                    result = new Invalidation();
+                    break;
+                case TIMESTAMP:
+                    result = new Timestamp();
+                    break;
+                default:
+                    result = null;
+            }
+            return result;
+        }
+    }
+
+}

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/serialization/MarkerWrapper.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/serialization/MarkerWrapper.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.serialization;
+
+import org.hibernate.cache.spi.access.SoftLock;
+
+/**
+ * A wrapper class for ExpiryMarker for returning copy of marker object with
+ * {@link SoftLock} marker interface.
+ */
+public class MarkerWrapper implements SoftLock {
+
+    private final ExpiryMarker marker;
+
+    public MarkerWrapper(final ExpiryMarker marker) {
+        this.marker = marker;
+    }
+
+    public ExpiryMarker getMarker() {
+        return marker;
+    }
+}
+

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/serialization/Value.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/serialization/Value.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.hazelcast.hibernate.serialization;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+
+import java.io.IOException;
+import java.util.Comparator;
+
+/**
+ * A value within a region cache
+ */
+public class Value extends Expirable {
+
+    private long timestamp;
+    private Object value;
+
+    public Value() {
+    }
+
+    public Value(final Object version, final long timestamp, final Object value) {
+        super(version);
+        this.timestamp = timestamp;
+        this.value = value;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean isReplaceableBy(final long txTimestamp, final Object newVersion,
+                                   final Comparator versionComparator) {
+        return version == null
+                ? timestamp <= txTimestamp
+                : versionComparator.compare(version, newVersion) < 0;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    @Override
+    public Object getValue() {
+        return value;
+    }
+
+    @Override
+    public Object getValue(final long txTimestamp) {
+        return timestamp <= txTimestamp ? value : null;
+    }
+
+    @Override
+    public boolean matches(final ExpiryMarker lock) {
+        return false;
+    }
+
+    @Override
+    public ExpiryMarker markForExpiration(final long timeout, final String nextMarkerId) {
+        return new ExpiryMarker(version, timeout, nextMarkerId);
+    }
+
+    @Override
+    public void readData(final ObjectDataInput in) throws IOException {
+        super.readData(in);
+        timestamp = in.readLong();
+        value = in.readObject();
+    }
+
+    @Override
+    public void writeData(final ObjectDataOutput out) throws IOException {
+        super.writeData(out);
+        out.writeLong(timestamp);
+        out.writeObject(value);
+    }
+
+    @Override
+    public int getFactoryId() {
+        return HibernateDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return HibernateDataSerializerHook.VALUE;
+    }
+
+}


### PR DESCRIPTION
Continuation of https://github.com/hazelcast/hazelcast-hibernate5/pull/117

Removing logic responsible for copying over classes from one module to the other