### PR TITLE
Make read-only access strategy ignore updates instead of throwing exceptions

### DIFF
--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/access/ReadOnlyAccessDelegate.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/access/ReadOnlyAccessDelegate.java
@@ -37,14 +37,11 @@ public class ReadOnlyAccessDelegate<T extends HazelcastRegion> extends NonStrict
         return cache.insert(key, value, version);
     }
 
-    /**
-     * @throws UnsupportedOperationException
-     */
     @Override
     public boolean afterUpdate(final Object key, final Object value, final Object currentVersion,
                                final Object previousVersion, final SoftLock lock) throws CacheException {
-        throw new UnsupportedOperationException("Cannot update an item in a read-only cache: "
-                + getHazelcastRegion().getName());
+        log.warning("Cannot update an item in a read-only cache: " + getHazelcastRegion().getName());
+        return false;
     }
 
     /**
@@ -59,16 +56,16 @@ public class ReadOnlyAccessDelegate<T extends HazelcastRegion> extends NonStrict
 
     @Override
     public SoftLock lockItem(final Object key, final Object version) throws CacheException {
+        log.warning("Attempting to lock an item in a read-only cache region: " + getHazelcastRegion().getName());
+
         return null;
     }
 
-    /**
-     * @throws UnsupportedOperationException
-     */
     @Override
     public SoftLock lockRegion() throws CacheException {
-        throw new UnsupportedOperationException("Attempting to lock a read-only cache region: "
-                + getHazelcastRegion().getName());
+        log.warning("Attempting to lock a read-only cache region: " + getHazelcastRegion().getName());
+
+        return null;
     }
 
     @Override
@@ -95,16 +92,14 @@ public class ReadOnlyAccessDelegate<T extends HazelcastRegion> extends NonStrict
      */
     @Override
     public void unlockRegion(final SoftLock lock) throws CacheException {
-        log.warning("Attempting to unlock a read-only cache region");
+        log.warning("Attempting to unlock a read-only cache region: " + getHazelcastRegion().getName());
     }
 
-    /**
-     * @throws UnsupportedOperationException
-     */
     @Override
     public boolean update(final Object key, final Object value, final Object currentVersion,
                           final Object previousVersion) throws CacheException {
-        throw new UnsupportedOperationException("Attempting to update an item in a read-only cache: "
-                + getHazelcastRegion().getName());
+        log.warning("Attempting to update an item in a read-only cache: " + getHazelcastRegion().getName());
+
+        return false;
     }
 }

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/CacheHitMissReadOnlyTest.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/CacheHitMissReadOnlyTest.java
@@ -15,14 +15,13 @@
 
 package com.hazelcast.hibernate;
 
-import com.hazelcast.hibernate.access.ReadOnlyAccessDelegate;
-import com.hazelcast.hibernate.region.HazelcastRegion;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.hibernate.cache.spi.access.AccessType;
 import org.hibernate.cfg.Environment;
 import org.hibernate.stat.SecondLevelCacheStatistics;
+import org.hibernate.stat.Statistics;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -30,8 +29,6 @@ import org.junit.runner.RunWith;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * Read-only access cache concurrency strategy of Hibernate.
@@ -57,8 +54,9 @@ public class CacheHitMissReadOnlyTest extends HibernateStatisticsTestSupport {
     public void testGetUpdateRemoveGet() throws Exception {
         insertDummyEntities(10, 4);
         //all 10 entities and 40 properties are cached
-        SecondLevelCacheStatistics dummyEntityCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_ENTITY);
-        SecondLevelCacheStatistics dummyPropertyCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_PROPERTY);
+        Statistics stats = sf.getStatistics();
+        SecondLevelCacheStatistics dummyEntityCacheStats = stats.getSecondLevelCacheStatistics(CACHE_ENTITY);
+        SecondLevelCacheStatistics dummyPropertyCacheStats = stats.getSecondLevelCacheStatistics(CACHE_PROPERTY);
 
         sf.getCache().evictEntityRegions();
         sf.getCache().evictCollectionRegions();
@@ -71,34 +69,5 @@ public class CacheHitMissReadOnlyTest extends HibernateStatisticsTestSupport {
         assertEquals(0, dummyPropertyCacheStats.getMissCount());
         assertEquals(1, dummyEntityCacheStats.getHitCount());
         assertEquals(10, dummyEntityCacheStats.getMissCount());
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testUpdateQueryCausesInvalidationOfEntireRegion() {
-        insertDummyEntities(10);
-        executeUpdateQuery("UPDATE DummyEntity set name = 'manually-updated' where id=2");
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testReadOnlyUpdate() {
-        insertDummyEntities(1, 0);
-        updateDummyEntityName(0, "updated");
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testAfterUpdateShouldThrowOnReadOnly() {
-        HazelcastRegion hzRegion = mock(HazelcastRegion.class);
-        when(hzRegion.getCache()).thenReturn(null);
-        when(hzRegion.getLogger()).thenReturn(null);
-        ReadOnlyAccessDelegate readOnlyAccessDelegate = new ReadOnlyAccessDelegate(hzRegion, null);
-        readOnlyAccessDelegate.afterUpdate(null, null, null, null, null);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testUpdateQueryCausesInvalidationOfEntireCollectionRegion() {
-        insertDummyEntities(1, 10);
-
-        //attempt to evict properties reference in DummyEntity because of custom SQL query on Collection region
-        executeUpdateQuery("update DummyProperty ent set ent.key='manually-updated'");
     }
 }

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/TopicReadOnlyTest.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/TopicReadOnlyTest.java
@@ -19,9 +19,6 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.hibernate.local.LocalRegionCache;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.SlowTest;
-import org.hibernate.Query;
-import org.hibernate.Session;
-import org.hibernate.Transaction;
 import org.hibernate.cache.spi.UpdateTimestampsCache;
 import org.hibernate.cache.spi.access.AccessType;
 import org.junit.Test;
@@ -77,67 +74,6 @@ public class TopicReadOnlyTest extends TopicReadOnlyTestSupport {
         assertTopicNotifications(6, CACHE_ENTITY_PROPERTIES);
         assertTopicNotifications(24, CACHE_PROPERTY);
         assertTopicNotifications(67, getTimestampsRegionName());
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testUpdateEntities() {
-        insertDummyEntities(1, 10);
-
-        executeUpdateQuery("update DummyEntity set name = 'updated-name' where id < 2");
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testUpdateEntitiesAndProperties() {
-        insertDummyEntities(1, 10);
-
-        Session session = null;
-        Transaction txn = null;
-        try {
-            session = sf.openSession();
-            txn = session.beginTransaction();
-            Query query = session.createQuery("update DummyEntity set name = 'updated-name' where id < 2");
-            query.setCacheable(true);
-            query.executeUpdate();
-
-            Query query2 = session.createQuery("update DummyProperty set version = version + 1");
-            query2.setCacheable(true);
-            query2.executeUpdate();
-
-            txn.commit();
-        } catch (RuntimeException e) {
-            txn.rollback();
-            e.printStackTrace();
-            throw e;
-        } finally {
-            session.close();
-        }
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testUpdateOneEntityAndProperties() {
-        insertDummyEntities(1, 10);
-
-        Session session = null;
-        Transaction txn = null;
-        try {
-            session = sf.openSession();
-            txn = session.beginTransaction();
-            Query query = session.createQuery("update DummyEntity set name = 'updated-name' where id = 0");
-            query.setCacheable(true);
-            query.executeUpdate();
-
-            Query query2 = session.createQuery("update DummyProperty set version = version + 1");
-            query2.setCacheable(true);
-            query2.executeUpdate();
-
-            txn.commit();
-        } catch (RuntimeException e) {
-            txn.rollback();
-            e.printStackTrace();
-            throw e;
-        } finally {
-            session.close();
-        }
     }
 
     protected AccessType getCacheStrategy() {

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/TopicReadOnlyTestSupport.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/TopicReadOnlyTestSupport.java
@@ -27,27 +27,6 @@ import java.util.HashSet;
 
 public abstract class TopicReadOnlyTestSupport extends HibernateTopicTestSupport {
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void testReplaceCollection() {
-        insertDummyEntities(2, 4);
-
-        Session session = sf.openSession();
-        Transaction transaction = session.beginTransaction();
-
-        DummyProperty property = new DummyProperty("somekey");
-        session.save(property);
-
-        DummyEntity entity = session.get(DummyEntity.class, 1L);
-        HashSet<DummyProperty> updatedProperties = new HashSet<DummyProperty>();
-        updatedProperties.add(property);
-        entity.setProperties(updatedProperties);
-
-        session.update(entity);
-
-        transaction.commit();
-        session.close();
-    }
-
     @Test
     public void testUpdateOneEntityByNaturalId() {
         insertAnnotatedEntities(2);
@@ -117,15 +96,6 @@ public abstract class TopicReadOnlyTestSupport extends HibernateTopicTestSupport
 
         assertTopicNotifications(4, CACHE_ANNOTATED_ENTITY + "##NaturalId");
         assertTopicNotifications(4, getTimestampsRegionName());
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testUpdateOneEntity() {
-        insertDummyEntities(10, 4);
-
-        getDummyEntities(10);
-
-        updateDummyEntityName(2, "updated");
     }
 
     @Override

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/entity/DummyEntity.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/entity/DummyEntity.java
@@ -91,4 +91,16 @@ public class DummyEntity {
     public Set<DummyProperty> getProperties() {
         return properties;
     }
+
+    @Override
+    public String toString() {
+        return "DummyEntity{" +
+          "id=" + id +
+          ", version=" + version +
+          ", name='" + name + '\'' +
+          ", value=" + value +
+          ", date=" + date +
+          ", properties=" + properties +
+          '}';
+    }
 }

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/access/ReadOnlyAccessDelegate.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/access/ReadOnlyAccessDelegate.java
@@ -37,14 +37,11 @@ public class ReadOnlyAccessDelegate<T extends HazelcastRegion> extends NonStrict
         return cache.insert(key, value, version);
     }
 
-    /**
-     * @throws UnsupportedOperationException
-     */
     @Override
     public boolean afterUpdate(final Object key, final Object value, final Object currentVersion,
                                final Object previousVersion, final SoftLock lock) throws CacheException {
-        throw new UnsupportedOperationException("Cannot update an item in a read-only cache: "
-                + getHazelcastRegion().getName());
+        log.warning("Cannot update an item in a read-only cache: " + getHazelcastRegion().getName());
+        return false;
     }
 
     /**
@@ -59,16 +56,16 @@ public class ReadOnlyAccessDelegate<T extends HazelcastRegion> extends NonStrict
 
     @Override
     public SoftLock lockItem(final Object key, final Object version) throws CacheException {
+        log.warning("Attempting to lock an item in a read-only cache region: " + getHazelcastRegion().getName());
+
         return null;
     }
 
-    /**
-     * @throws UnsupportedOperationException
-     */
     @Override
     public SoftLock lockRegion() throws CacheException {
-        throw new UnsupportedOperationException("Attempting to lock a read-only cache region: "
-                + getHazelcastRegion().getName());
+        log.warning("Attempting to lock a read-only cache region: " + getHazelcastRegion().getName());
+
+        return null;
     }
 
     @Override
@@ -83,10 +80,6 @@ public class ReadOnlyAccessDelegate<T extends HazelcastRegion> extends NonStrict
      */
     @Override
     public void unlockItem(final Object key, final SoftLock lock) throws CacheException {
-        /*
-         * To err on the safe side though, follow ReadOnlyEhcacheEntityRegionAccessStrategy which nevertheless evicts
-         * the key.
-         */
         evict(key);
     }
 
@@ -95,16 +88,14 @@ public class ReadOnlyAccessDelegate<T extends HazelcastRegion> extends NonStrict
      */
     @Override
     public void unlockRegion(final SoftLock lock) throws CacheException {
-        log.warning("Attempting to unlock a read-only cache region");
+        log.warning("Attempting to unlock a read-only cache region: " + getHazelcastRegion().getName());
     }
 
-    /**
-     * @throws UnsupportedOperationException
-     */
     @Override
     public boolean update(final Object key, final Object value, final Object currentVersion,
                           final Object previousVersion) throws CacheException {
-        throw new UnsupportedOperationException("Attempting to update an item in a read-only cache: "
-                + getHazelcastRegion().getName());
+        log.warning("Attempting to update an item in a read-only cache: " + getHazelcastRegion().getName());
+
+        return false;
     }
 }

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/TopicReadOnlyTest.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/TopicReadOnlyTest.java
@@ -79,67 +79,6 @@ public class TopicReadOnlyTest extends TopicReadOnlyTestSupport {
         assertTopicNotifications(67, getTimestampsRegionName());
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void testUpdateEntities() {
-        insertDummyEntities(1, 10);
-
-        executeUpdateQuery("update DummyEntity set name = 'updated-name' where id < 2");
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testUpdateEntitiesAndProperties() {
-        insertDummyEntities(1, 10);
-
-        Session session = null;
-        Transaction txn = null;
-        try {
-            session = sf.openSession();
-            txn = session.beginTransaction();
-            Query query = session.createQuery("update DummyEntity set name = 'updated-name' where id < 2");
-            query.setCacheable(true);
-            query.executeUpdate();
-
-            Query query2 = session.createQuery("update DummyProperty set version = version + 1");
-            query2.setCacheable(true);
-            query2.executeUpdate();
-
-            txn.commit();
-        } catch (RuntimeException e) {
-            txn.rollback();
-            e.printStackTrace();
-            throw e;
-        } finally {
-            session.close();
-        }
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testUpdateOneEntityAndProperties() {
-        insertDummyEntities(1, 10);
-
-        Session session = null;
-        Transaction txn = null;
-        try {
-            session = sf.openSession();
-            txn = session.beginTransaction();
-            Query query = session.createQuery("update DummyEntity set name = 'updated-name' where id = 0");
-            query.setCacheable(true);
-            query.executeUpdate();
-
-            Query query2 = session.createQuery("update DummyProperty set version = version + 1");
-            query2.setCacheable(true);
-            query2.executeUpdate();
-
-            txn.commit();
-        } catch (RuntimeException e) {
-            txn.rollback();
-            e.printStackTrace();
-            throw e;
-        } finally {
-            session.close();
-        }
-    }
-
     protected AccessType getCacheStrategy() {
         return AccessType.READ_ONLY;
     }

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/TopicReadOnlyTestSupport.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/TopicReadOnlyTestSupport.java
@@ -16,37 +16,12 @@
 package com.hazelcast.hibernate;
 
 import com.hazelcast.hibernate.entity.AnnotatedEntity;
-import com.hazelcast.hibernate.entity.DummyEntity;
-import com.hazelcast.hibernate.entity.DummyProperty;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.cache.spi.access.AccessType;
 import org.junit.Test;
 
-import java.util.HashSet;
-
 public abstract class TopicReadOnlyTestSupport extends HibernateTopicTestSupport {
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testReplaceCollection() {
-        insertDummyEntities(2, 4);
-
-        Session session = sf.openSession();
-        Transaction transaction = session.beginTransaction();
-
-        DummyProperty property = new DummyProperty("somekey");
-        session.save(property);
-
-        DummyEntity entity = session.get(DummyEntity.class, 1L);
-        HashSet<DummyProperty> updatedProperties = new HashSet<DummyProperty>();
-        updatedProperties.add(property);
-        entity.setProperties(updatedProperties);
-
-        session.update(entity);
-
-        transaction.commit();
-        session.close();
-    }
 
     @Test
     public void testUpdateOneEntityByNaturalId() {
@@ -117,15 +92,6 @@ public abstract class TopicReadOnlyTestSupport extends HibernateTopicTestSupport
 
         assertTopicNotifications(4, CACHE_ANNOTATED_ENTITY + "##NaturalId");
         assertTopicNotifications(4, getTimestampsRegionName());
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testUpdateOneEntity() {
-        insertDummyEntities(10, 4);
-
-        getDummyEntities(10);
-
-        updateDummyEntityName(2, "updated");
     }
 
     @Override

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/entity/DummyEntity.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/entity/DummyEntity.java
@@ -91,4 +91,16 @@ public class DummyEntity {
     public Set<DummyProperty> getProperties() {
         return properties;
     }
+
+    @Override
+    public String toString() {
+        return "DummyEntity{" +
+          "id=" + id +
+          ", version=" + version +
+          ", name='" + name + '\'' +
+          ", value=" + value +
+          ", date=" + date +
+          ", properties=" + properties +
+          '}';
+    }
 }

--- a/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/TopicReadOnlyTest53.java
+++ b/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/TopicReadOnlyTest53.java
@@ -19,11 +19,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.hibernate.local.LocalRegionCache;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.SlowTest;
-import org.hibernate.Session;
-import org.hibernate.Transaction;
 import org.hibernate.cache.spi.RegionFactory;
-import org.hibernate.query.Query;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -84,75 +80,5 @@ public class TopicReadOnlyTest53 extends TopicReadOnlyTestSupport {
         assertTopicNotifications(3, CACHE_ENTITY_PROPERTIES);
         assertTopicNotifications(24, CACHE_PROPERTY);
         assertTopicNotifications(67, getTimestampsRegionName());
-    }
-
-    // This test should throw an UnsupportedOperationException, for attempting an update on a read-only cache,
-    // but in Hibernate 5.3 the exception is not thrown.
-    @Ignore
-    @Test(expected = UnsupportedOperationException.class)
-    public void testUpdateEntities() {
-        insertDummyEntities(1, 10);
-
-        executeUpdateQuery("update DummyEntity set name = 'updated-name' where id < 2");
-    }
-
-    // This test should throw an UnsupportedOperationException, for attempting an update on a read-only cache,
-    // but in Hibernate 5.3 the exception is not thrown.
-    @Ignore
-    @Test(expected = UnsupportedOperationException.class)
-    public void testUpdateEntitiesAndProperties() {
-        insertDummyEntities(1, 10);
-
-        Session session = null;
-        Transaction txn = null;
-        try {
-            session = sf.openSession();
-            txn = session.beginTransaction();
-            Query query = session.createQuery("update DummyEntity set name = 'updated-name' where id < 2");
-            query.setCacheable(true);
-            query.executeUpdate();
-
-            Query query2 = session.createQuery("update DummyProperty set version = version + 1");
-            query2.setCacheable(true);
-            query2.executeUpdate();
-
-            txn.commit();
-        } catch (RuntimeException e) {
-            txn.rollback();
-            e.printStackTrace();
-            throw e;
-        } finally {
-            session.close();
-        }
-    }
-
-    // This test should throw an UnsupportedOperationException, for attempting an update on a read-only cache,
-    // but in Hibernate 5.3 the exception is not thrown.
-    @Ignore
-    @Test(expected = UnsupportedOperationException.class)
-    public void testUpdateOneEntityAndProperties() {
-        insertDummyEntities(1, 10);
-
-        Session session = null;
-        Transaction txn = null;
-        try {
-            session = sf.openSession();
-            txn = session.beginTransaction();
-            Query query = session.createQuery("update DummyEntity set name = 'updated-name' where id = 0");
-            query.setCacheable(true);
-            query.executeUpdate();
-
-            Query query2 = session.createQuery("update DummyProperty set version = version + 1");
-            query2.setCacheable(true);
-            query2.executeUpdate();
-
-            txn.commit();
-        } catch (RuntimeException e) {
-            txn.rollback();
-            e.printStackTrace();
-            throw e;
-        } finally {
-            session.close();
-        }
     }
 }

--- a/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/entity/DummyEntity.java
+++ b/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/entity/DummyEntity.java
@@ -91,4 +91,16 @@ public class DummyEntity {
     public Set<DummyProperty> getProperties() {
         return properties;
     }
+
+    @Override
+    public String toString() {
+        return "DummyEntity{" +
+          "id=" + id +
+          ", version=" + version +
+          ", name='" + name + '\'' +
+          ", value=" + value +
+          ", date=" + date +
+          ", properties=" + properties +
+          '}';
+    }
 }


### PR DESCRIPTION
Aligned the behaviour of _read-only_ access strategy `hazelcast-hibernate5` and `hazelcast-hibernate52` to Hibernate-provided implementation from `hazelcast-hibernate53`.

Removed copy-pasted tests.

----
fixes: https://github.com/hazelcast/hazelcast-hibernate5/issues/29